### PR TITLE
fix: 修复用户歌单列表未分页，导致歌单数量>30时后续歌单无法加载的问题

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
@@ -153,11 +153,27 @@ public partial class MyPlaylistsViewModel : PageViewModelBase
         if (!_userClient.IsLoggedIn())
             return;
 
-        var onlinePlaylists = await _userClient.GetPlaylistsAsync();
-        if (onlinePlaylists is not null && onlinePlaylists.Status == 1)
+        const int playlistPageSize = 100;
+        var allPlaylists = new List<UserPlaylistItem>();
+
+        var firstPage = await _userClient.GetPlaylistsAsync(page: 1, pageSize: playlistPageSize);
+        if (firstPage?.Status == 1 && firstPage.Playlists.Count > 0)
+        {
+            allPlaylists.AddRange(firstPage.Playlists);
+            var totalPages = (int)Math.Ceiling(firstPage.ListCount / (double)playlistPageSize);
+            for (int page = 2; page <= totalPages; page++)
+            {
+                var nextPage = await _userClient.GetPlaylistsAsync(page, playlistPageSize);
+                if (nextPage?.Playlists.Count > 0)
+                    allPlaylists.AddRange(nextPage.Playlists);
+            }
+            allPlaylists.Sort((a, b) => b.CreateTime.CompareTo(a.CreateTime));
+        }
+
+        if (allPlaylists.Count > 0)
         {
             var onlineItems = new List<PlaylistItem>();
-            foreach (var item in onlinePlaylists.Playlists)
+            foreach (var item in allPlaylists)
                 if (!string.IsNullOrEmpty(item.ListCreateId) || item.IsCollectedAlbum)
                     onlineItems.Add(new PlaylistItem
                     {
@@ -177,7 +193,7 @@ public partial class MyPlaylistsViewModel : PageViewModelBase
         }
         else
         {
-            _logger.LogError($"加载失败,err_code{onlinePlaylists?.ErrorCode}");
+            _logger.LogError($"加载失败,err_code{firstPage?.ErrorCode}");
             if (_favoritePlaylistService.TryGetLikePlaylistCache(out var cachedLike))
             {
                 Items.Add(cachedLike.Playlist);

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
@@ -154,26 +154,26 @@ public partial class MyPlaylistsViewModel : PageViewModelBase
             return;
 
         const int playlistPageSize = 100;
-        var allPlaylists = new List<UserPlaylistItem>();
+        var onlinePlaylists = new List<UserPlaylistItem>();
 
         var firstPage = await _userClient.GetPlaylistsAsync(page: 1, pageSize: playlistPageSize);
         if (firstPage?.Status == 1 && firstPage.Playlists.Count > 0)
         {
-            allPlaylists.AddRange(firstPage.Playlists);
+            onlinePlaylists.AddRange(firstPage.Playlists);
             var totalPages = (int)Math.Ceiling(firstPage.ListCount / (double)playlistPageSize);
             for (int page = 2; page <= totalPages; page++)
             {
-                var nextPage = await _userClient.GetPlaylistsAsync(page, playlistPageSize);
-                if (nextPage?.Playlists.Count > 0)
-                    allPlaylists.AddRange(nextPage.Playlists);
+                var pageResult = await _userClient.GetPlaylistsAsync(page, playlistPageSize);
+                if (pageResult?.Playlists.Count > 0)
+                    onlinePlaylists.AddRange(pageResult.Playlists);
             }
-            allPlaylists.Sort((a, b) => b.CreateTime.CompareTo(a.CreateTime));
+            onlinePlaylists.Sort((a, b) => b.CreateTime.CompareTo(a.CreateTime));
         }
 
-        if (allPlaylists.Count > 0)
+        if (onlinePlaylists.Count > 0)
         {
             var onlineItems = new List<PlaylistItem>();
-            foreach (var item in allPlaylists)
+            foreach (var item in onlinePlaylists)
                 if (!string.IsNullOrEmpty(item.ListCreateId) || item.IsCollectedAlbum)
                     onlineItems.Add(new PlaylistItem
                     {


### PR DESCRIPTION
- pageSize 从默认30改为100
- 根据 ListCount 计算总页数，循环拉取所有页
- 合并到 allPlaylists 后再处理