### PR TITLE
feat: add pagination for playlist and album search

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SearchViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SearchViewModel.cs
@@ -224,18 +224,47 @@ public partial class SearchViewModel(
 
     private async Task SearchPlaylists()
     {
-        var results = await searchClient.SearchSpecialAsync(SearchKeyword);
-        if (results != null)
-            foreach (var item in results)
-                Playlists.Add(item);
+        for (int page = 1; ; page++)
+        {
+            try
+            {
+                var results = await searchClient.SearchSpecialAsync(SearchKeyword, page);
+                if (results == null || results.Count == 0) break;
+
+                foreach (var item in results)
+                    Playlists.Add(item);
+
+                if (results.Count < 30) break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "网络问题，歌单搜索中断");
+                break;
+            }
+        }
     }
 
     private async Task SearchAlbums()
     {
-        var results = await searchClient.SearchAlbumAsync(SearchKeyword);
-        if (results != null)
-            foreach (var item in results)
-                Albums.Add(item);
+        for (int page = 1; ; page++)
+        {
+            try
+            {
+                var results = await searchClient.SearchAlbumAsync(SearchKeyword, page);
+                if (results == null || results.Count == 0) break;
+
+                var sorted = results.OrderBy(x => x.PublishTime).ToList();
+                foreach (var item in sorted)
+                    Albums.Add(item);
+
+                if (results.Count < 30) break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "网络问题，专辑搜索中断");
+                break;
+            }
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
    feat: add pagination for playlist and album search
    
    Summary
    - 歌单搜索添加分页循环加载（自动翻页直到数据不足30条或出错）
    - 专辑搜索添加分页循环加载，并按发布时间升序排列（早的在前）
    - 网络异常时记录日志并中断搜索
    
    Changes
    - SearchViewModel.cs: SearchPlaylists() / SearchAlbums() 改为 for 循环分页加载
    - SearchAlbums() 追加 .OrderBy(x => x.PublishTime) 排序
    
    Test Plan
    - [✓] 搜索歌单，确认多页数据正确加载
    - [✓] 搜索专辑，确认多页数据加载且按时间正序排列