### PR TITLE
Fix：修复对播放中的歌曲执行下一曲操作时的问题，修复SongItem比较问题

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
@@ -197,7 +197,7 @@
                                         ToolTip.Tip="{Binding #Root.HeroActionText}"
                                         ToolTip.ServiceEnabled="{Binding #Root.HasHeroActionText}"
                                         ToolTip.Placement="Top"
-                                        ToolTip.VerticalOffset="20">
+                                        ToolTip.VerticalOffset="-2">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <Svg Classes="ThemeSvgIcon"
                                              Path="{Binding #Root.HeroActionSvgPath}"
@@ -218,7 +218,7 @@
                                         Cursor="Hand"
                                         ToolTip.Tip="批量操作"
                                         ToolTip.Placement="Top"
-                                        ToolTip.VerticalOffset="20">
+                                        ToolTip.VerticalOffset="-2">
                                     <Svg Classes="ThemeSvgIcon" Path="/Assets/FormatList.svg" Width="16" Height="16" />
                                 </Button>
                             </Grid>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
@@ -193,7 +193,11 @@
                                         Command="{Binding #Root.HeroActionCommand}"
                                         IsVisible="{Binding #Root.HasHeroAction}"
                                         VerticalAlignment="Center"
-                                        Cursor="Hand">
+                                        Cursor="Hand"
+                                        ToolTip.Tip="{Binding #Root.HeroActionText}"
+                                        ToolTip.ServiceEnabled="{Binding #Root.HasHeroActionText}"
+                                        ToolTip.Placement="Top"
+                                        ToolTip.VerticalOffset="20">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <Svg Classes="ThemeSvgIcon"
                                              Path="{Binding #Root.HeroActionSvgPath}"
@@ -204,9 +208,6 @@
                                                   Width="16"
                                                   Height="16"
                                                   IsVisible="{Binding #Root.HasHeroActionIconData}" />
-                                        <TextBlock Text="{Binding #Root.HeroActionText}"
-                                                   IsVisible="{Binding #Root.HasHeroActionText}"
-                                                   VerticalAlignment="Center" />
                                     </StackPanel>
                                 </Button>
 
@@ -215,7 +216,9 @@
                                         Command="{Binding #Root.OpenBatchActionsCommand}"
                                         IsVisible="{Binding #Root.ShowAddLoadedSongsToQueueButton}"
                                         Cursor="Hand"
-                                        ToolTip.Tip="批量操作">
+                                        ToolTip.Tip="批量操作"
+                                        ToolTip.Placement="Top"
+                                        ToolTip.VerticalOffset="20">
                                     <Svg Classes="ThemeSvgIcon" Path="/Assets/FormatList.svg" Width="16" Height="16" />
                                 </Button>
                             </Grid>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
@@ -497,7 +497,7 @@ public partial class SongCollectionDetailView : UserControl
         var playingSong = Songs?
             .AsValueEnumerable()
             .OfType<SongItem>()
-            .FirstOrDefault(song => IsSameSong(song, currentSong));
+            .FirstOrDefault(song => song==currentSong);
 
         if (playingSong is null)
         {
@@ -581,7 +581,7 @@ public partial class SongCollectionDetailView : UserControl
                 return;
 
             foreach (var song in songs)
-                song.IsPlaying = IsSameSong(song, currentSong);
+                song.IsPlaying = song == currentSong;
         }
 
         if (Dispatcher.UIThread.CheckAccess())
@@ -590,17 +590,6 @@ public partial class SongCollectionDetailView : UserControl
             Dispatcher.UIThread.Post(Update);
     }
 
-    private static bool IsSameSong(SongItem candidate, SongItem? currentSong)
-    {
-        if (currentSong is null)
-            return false;
-
-        if (ReferenceEquals(candidate, currentSong))
-            return true;
-
-        return !string.IsNullOrWhiteSpace(candidate.Hash) &&
-               string.Equals(candidate.Hash, currentSong.Hash, StringComparison.OrdinalIgnoreCase);
-    }
 
     private void AdjustScrollPosition(SongItem playingSong)
     {

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.Queue.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.Queue.cs
@@ -271,11 +271,15 @@ public partial class PlayerViewModel
     }
 
     [RelayCommand]
-    private void RemoveFromQueue(SongItem song)
-    {
+    private async Task RemoveFromQueue(SongItem song) {
+        if (song == CurrentPlayingSong) {
+            if (_queueManager.PlaybackQueue.Count <= 1)
+                StopAndReset();
+            else
+                await PlaySongAsync(_queueManager.GetNext(CurrentPlayingSong));
+        }
+
         _queueManager.Remove(song);
-        if (_queueManager.PlaybackQueue.Count == 0)
-            StopAndReset();
 
         SchedulePlaybackQueueCacheSave();
     }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.cs
@@ -197,7 +197,20 @@ public partial class PlayerViewModel : ViewModelBase, IDisposable
             (_, m) =>
             {
                 if (!AddSongToPersonalFmNext(m.Song))
-                    _queueManager.AddToNext(m.Song, CurrentPlayingSong);
+                    if (m.Song == CurrentPlayingSong) {
+                        _toastManager.CreateToast()
+                                     .OfType(NotificationType.Error)
+                                     .WithTitle("添加失败")
+                                     .WithContent("当前正在播放的歌曲不能添加到下一首")
+                                     .Dismiss()
+                                     .After(TimeSpan.FromSeconds(3))
+                                     .Dismiss()
+                                     .ByClicking()
+                                     .Queue();
+                        return;
+                    }
+
+                _queueManager.AddToNext(m.Song, CurrentPlayingSong);
             });
         WeakReferenceMessenger.Default.Register<AddLoadedSongsToQueueMessage>(this,
             (_, m) => AddLoadedSongsToQueue(m.Songs));

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SongItem.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SongItem.cs
@@ -31,14 +31,12 @@ public partial class SongItem : ObservableObject
     [ObservableProperty]
     public partial long FileId { get; set; }
 
-    [ObservableProperty]
-    public partial string Hash { get; set; } = "";
+    public string Hash { get; init; } = "";
 
     [ObservableProperty]
     public partial bool IsPlaying { get; set; }
 
-    [ObservableProperty]
-    public partial string? LocalFilePath { get; set; }
+    public string? LocalFilePath { get; init; }
 
     [ObservableProperty]
     public partial string? LocalSourceType { get; set; }
@@ -46,8 +44,7 @@ public partial class SongItem : ObservableObject
     [ObservableProperty]
     public partial long LocalTrackId { get; set; }
 
-    [ObservableProperty]
-    public partial string? RemoteUrl { get; set; }
+    public string? RemoteUrl { get; init; }
 
     [ObservableProperty]
     public partial string Name { get; set; } = "";
@@ -57,6 +54,7 @@ public partial class SongItem : ObservableObject
 
     [ObservableProperty]
     public partial string Singer { get; set; } = "";
+
     public List<SingerLite> Singers { get; set; } = new();
 
     public string DisplayTitle => NormalizeDisplayTitle(Name, Singer);
@@ -129,6 +127,20 @@ public partial class SongItem : ObservableObject
 
         return trimmedName;
     }
+
+    public static bool operator ==(SongItem? a, SongItem? b) =>
+        (a is null && b is null) ||
+        (!string.IsNullOrWhiteSpace(a?.LocalFilePath) && a.LocalFilePath == b?.LocalFilePath) ||
+        (!string.IsNullOrWhiteSpace(a?.RemoteUrl) && a.RemoteUrl == b?.RemoteUrl && a.Hash == b.Hash);
+
+    public static bool operator !=(SongItem? a, SongItem? b) => !(a == b);
+
+    public override bool Equals(object? obj) => obj is SongItem item && this == item;
+
+    public override int GetHashCode() =>
+        string.IsNullOrWhiteSpace(Hash) ?
+            HashCode.Combine(LocalFilePath ?? RemoteUrl) :
+            HashCode.Combine(LocalFilePath ?? RemoteUrl, Hash);
 }
 
 public partial class PlaylistItem : ObservableObject


### PR DESCRIPTION
修复对播放中的歌曲执行下一曲操作时的问题
修复SongItem比较问题，现在两个相同的音频项目可以正确比较了
修复播放中的歌曲在多种情况下无法被歌单选项识别的问题
修复按钮闪烁问题
修复添加歌曲按钮的文字位置问题（将其移到ToolTip）
Fixes #38 