### PR TITLE
feat: 本地歌曲的本地歌单搜索功能(模糊/精确搜索)

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml
@@ -1,0 +1,245 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:KugouAvaloniaPlayer.ViewModels"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
+             xmlns:behaviors="using:KugouAvaloniaPlayer.Behaviors"
+             xmlns:asyncImageLoader="clr-namespace:AsyncImageLoader;assembly=AsyncImageLoader.Avalonia"
+             x:Class="KugouAvaloniaPlayer.Controls.LocalMusicSearchDialog"
+             x:Name="SearchDialogRoot"
+             x:DataType="vm:LocalMusicSearchDialogViewModel">
+
+    <UserControl.Styles>
+        <Style Selector="ListBox.LocalMusicSearchList">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+            <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="False" />
+        </Style>
+
+        <Style Selector="ListBox.LocalMusicSearchList ListBoxItem">
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Padding="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      Background="Transparent" />
+                </ControlTemplate>
+            </Setter>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Width="920"
+            MaxHeight="720"
+            Padding="22"
+            Background="{DynamicResource SukiBackground}"
+            CornerRadius="18">
+        <Grid RowDefinitions="Auto,Auto,*,Auto">
+            <StackPanel Spacing="6"
+                        Margin="0,0,0,16">
+                <TextBlock Text="搜索本地歌曲"
+                           FontSize="26"
+                           FontWeight="Bold" />
+                <TextBlock Text="搜索已加入本地音乐库歌单的全部歌曲"
+                           Foreground="{DynamicResource SukiLowText}" />
+            </StackPanel>
+
+            <Grid Grid.Row="1"
+                  ColumnDefinitions="*,Auto"
+                  ColumnSpacing="10"
+                  Margin="0,0,0,16">
+                <TextBox x:Name="SearchBox"
+                         PlaceholderText="搜索歌曲、歌手、专辑或歌单"
+                         Text="{Binding SearchText}"
+                         behaviors:InteractionBehaviors.EnterKeyCommand="{Binding SearchCommand}" />
+
+                <Button Grid.Column="1"
+                        Classes="Standard"
+                        MinWidth="44"
+                        Cursor="Hand"
+                        Command="{Binding SearchCommand}"
+                        ToolTip.Tip="搜索">
+                    <PathIcon Data="{x:Static suki:Icons.Search}"
+                              Width="18"
+                              Height="18" />
+                </Button>
+            </Grid>
+
+            <Grid Grid.Row="2">
+                <StackPanel HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="8"
+                            IsVisible="{Binding ShowPromptState}">
+                    <PathIcon Data="{x:Static suki:Icons.Search}"
+                              Width="30"
+                              Height="30"
+                              Foreground="{DynamicResource SukiLowText}" />
+                    <TextBlock Text="输入关键词后按 Enter 或点击搜索按钮"
+                               Foreground="{DynamicResource SukiLowText}" />
+                </StackPanel>
+
+                <StackPanel HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="10"
+                            IsVisible="{Binding IsSearching}">
+                    <suki:Loading Width="40" Height="40" />
+                    <TextBlock Text="正在搜索本地音乐库..."
+                               Foreground="{DynamicResource SukiLiquid2}" />
+                </StackPanel>
+
+                <Border IsVisible="{Binding ShowEmptyState}"
+                        Padding="24"
+                        CornerRadius="16"
+                        Background="{DynamicResource SukiPrimaryColorLow}">
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="8">
+                        <TextBlock Text="没有找到匹配的歌曲"
+                                   FontSize="16"
+                                   FontWeight="SemiBold"
+                                   HorizontalAlignment="Center" />
+                        <TextBlock Text="换个关键词试试。"
+                                   Foreground="{DynamicResource SukiLowText}"
+                                   HorizontalAlignment="Center" />
+                    </StackPanel>
+                </Border>
+
+                <Border IsVisible="{Binding HasError}"
+                        Padding="24"
+                        CornerRadius="16"
+                        Background="{DynamicResource SukiPrimaryColorLow}">
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="10">
+                        <TextBlock Text="搜索失败"
+                                   FontSize="16"
+                                   FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding ErrorMessage}"
+                                   MaxWidth="640"
+                                   TextWrapping="Wrap"
+                                   TextAlignment="Center"
+                                   Foreground="{DynamicResource SukiLowText}" />
+                        <Button Classes="Basic"
+                                Command="{Binding SearchCommand}"
+                                Cursor="Hand">
+                            <TextBlock Text="重试" />
+                        </Button>
+                    </StackPanel>
+                </Border>
+
+                <Grid RowDefinitions="Auto,*"
+                      IsVisible="{Binding HasResults}">
+                    <Grid ColumnDefinitions="72,*,140,140,80,100"
+                          ColumnSpacing="12"
+                          Margin="12,0,12,8">
+                        <TextBlock Grid.Column="1" Text="歌曲" Foreground="{DynamicResource SukiLowText}" />
+                        <TextBlock Grid.Column="2" Text="专辑" Foreground="{DynamicResource SukiLowText}" />
+                        <TextBlock Grid.Column="3" Text="对应歌单" Foreground="{DynamicResource SukiLowText}" />
+                        <TextBlock Grid.Column="4" Text="时长" Foreground="{DynamicResource SukiLowText}" />
+                        <TextBlock Grid.Column="5"
+                                   Text="操作"
+                                   HorizontalAlignment="Right"
+                                   Foreground="{DynamicResource SukiLowText}" />
+                    </Grid>
+
+                    <ListBox Grid.Row="1"
+                             Classes="LocalMusicSearchList"
+                             ItemsSource="{Binding Results}"
+                             MaxHeight="440">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="vm:LocalMusicSearchResultItemViewModel">
+                                <Border Margin="0,0,0,10"
+                                        Padding="12"
+                                        CornerRadius="16"
+                                        Background="{DynamicResource SukiPrimaryColorLow}"
+                                        behaviors:InteractionBehaviors.DoubleTappedCommand="{Binding #SearchDialogRoot.((vm:LocalMusicSearchDialogViewModel)DataContext).OpenResultCommand}"
+                                        behaviors:InteractionBehaviors.DoubleTappedCommandParameter="{Binding}">
+                                    <Grid ColumnDefinitions="72,*,140,140,80,100"
+                                          ColumnSpacing="12">
+                                        <Border Width="60"
+                                                Height="60"
+                                                CornerRadius="12"
+                                                ClipToBounds="True"
+                                                Background="{DynamicResource SukiPrimaryColor0}">
+                                            <Image asyncImageLoader:ImageLoader.Source="{Binding Cover}"
+                                                   behaviors:ImageRenderOptions.InterpolationSource="{Binding Cover}"
+                                                   Stretch="UniformToFill" />
+                                        </Border>
+
+                                        <StackPanel Grid.Column="1"
+                                                    VerticalAlignment="Center"
+                                                    Spacing="4">
+                                            <TextBlock Text="{Binding Title}"
+                                                       FontWeight="SemiBold"
+                                                       TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Text="{Binding Artist}"
+                                                       Foreground="{DynamicResource SukiLowText}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding Album}"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   TextTrimming="CharacterEllipsis" />
+
+                                        <TextBlock Grid.Column="3"
+                                                   Text="{Binding PlaylistName}"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource SukiLowText}"
+                                                   TextTrimming="CharacterEllipsis" />
+
+                                        <TextBlock Grid.Column="4"
+                                                   Text="{Binding DurationSeconds, Converter={StaticResource SecondsToTimeConverter}}"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource SukiLowText}" />
+
+                                        <Button Grid.Column="5"
+                                                Classes="Basic"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Cursor="Hand"
+                                                Command="{Binding #SearchDialogRoot.((vm:LocalMusicSearchDialogViewModel)DataContext).OpenResultCommand}"
+                                                CommandParameter="{Binding}">
+                                            <TextBlock Text="打开歌单" />
+                                        </Button>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Grid>
+            </Grid>
+
+            <Grid Grid.Row="3"
+                  ColumnDefinitions="*,Auto"
+                  Margin="0,18,0,0">
+                <TextBlock Text="{Binding Results.Count, StringFormat='找到 {0} 条结果'}"
+                           IsVisible="{Binding HasResults}"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource SukiLowText}" />
+
+                <Button Grid.Column="1"
+                        Classes="Basic"
+                        Command="{Binding CancelCommand}"
+                        Cursor="Hand">
+                    <TextBlock Text="关闭" />
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml
@@ -1,4 +1,4 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+ <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:KugouAvaloniaPlayer.ViewModels"
              xmlns:suki="https://github.com/kikipoulet/SukiUI"
@@ -35,6 +35,20 @@
                                       Background="Transparent" />
                 </ControlTemplate>
             </Setter>
+        </Style>
+        <Style Selector="suki|GlassCard.ToggleExpansion PathIcon.ExpansionIcon">
+            <Setter Property="Transitions">
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.3" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="suki|GlassCard.ToggleExpansion PathIcon.Collapsed">
+            <Setter Property="RenderTransform" Value="rotate(0deg)" />
+        </Style>
+        <!-- Expand toggle chevron rotation -->
+        <Style Selector="suki|GlassCard.ToggleExpansion PathIcon.Expanded">
+            <Setter Property="RenderTransform" Value="rotate(90deg)" />
         </Style>
     </UserControl.Styles>
 
@@ -136,41 +150,51 @@
                     </StackPanel>
                 </Border>
 
-                <Grid RowDefinitions="Auto,*"
+                <Grid RowDefinitions="Auto,*" Margin="10 5"
                       IsVisible="{Binding HasResults}">
-                    <Grid ColumnDefinitions="72,*,140,140,80,100"
-                          ColumnSpacing="12"
-                          Margin="12,0,12,8">
-                        <TextBlock Grid.Column="1" Text="歌曲" Foreground="{DynamicResource SukiLowText}" />
-                        <TextBlock Grid.Column="2" Text="专辑" Foreground="{DynamicResource SukiLowText}" />
-                        <TextBlock Grid.Column="3" Text="对应歌单" Foreground="{DynamicResource SukiLowText}" />
-                        <TextBlock Grid.Column="4" Text="时长" Foreground="{DynamicResource SukiLowText}" />
-                        <TextBlock Grid.Column="5"
-                                   Text="操作"
-                                   HorizontalAlignment="Right"
-                                   Foreground="{DynamicResource SukiLowText}" />
-                    </Grid>
+                    <suki:GlassCard Background="{x:Null}" BorderBrush="{x:Null}" BorderThickness="0" CornerRadius="0"
+                                    Padding="10 0">
+                        <Grid ColumnDefinitions="50,72,*,140,40"
+                              ColumnSpacing="12">
+                            <TextBlock Grid.Column="2" Text="歌曲" Foreground="{DynamicResource SukiLowText}" />
+                            <TextBlock Grid.Column="3" Text="专辑" Foreground="{DynamicResource SukiLowText}" />
+                            <TextBlock Grid.Column="4" Text="时长" Foreground="{DynamicResource SukiLowText}" />
+                        </Grid>
+                    </suki:GlassCard>
 
                     <ListBox Grid.Row="1"
                              Classes="LocalMusicSearchList"
                              ItemsSource="{Binding Results}"
-                             MaxHeight="440">
+                             MaxHeight="440"
+                             ScrollViewer.VerticalScrollBarVisibility="Hidden">
                         <ListBox.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <VirtualizingStackPanel />
                             </ItemsPanelTemplate>
                         </ListBox.ItemsPanel>
                         <ListBox.ItemTemplate>
-                            <DataTemplate DataType="vm:LocalMusicSearchResultItemViewModel">
-                                <Border Margin="0,0,0,10"
-                                        Padding="12"
-                                        CornerRadius="16"
-                                        Background="{DynamicResource SukiPrimaryColorLow}"
-                                        behaviors:InteractionBehaviors.DoubleTappedCommand="{Binding #SearchDialogRoot.((vm:LocalMusicSearchDialogViewModel)DataContext).OpenResultCommand}"
-                                        behaviors:InteractionBehaviors.DoubleTappedCommandParameter="{Binding}">
-                                    <Grid ColumnDefinitions="72,*,140,140,80,100"
-                                          ColumnSpacing="12">
-                                        <Border Width="60"
+                            <DataTemplate DataType="vm:GroupedSearchResultItemViewModel">
+                                <suki:GlassCard Classes="ToggleExpansion" IsInteractive="True"
+                                                Command="{Binding ToggleExpandCommand}"
+                                                CornerRadius="16"
+                                                Padding="10 5"
+                                                Background="{DynamicResource SukiPrimaryColorLow}">
+                                    <Grid RowDefinitions="Auto,Auto"
+                                          ColumnSpacing="12"
+                                          ColumnDefinitions="50,72,*,140,40">
+
+
+                                        <PathIcon
+                                            Classes.ExpansionIcon="True"
+                                            Classes.Collapsed="{Binding !IsExpanded}"
+                                            Classes.Expanded="{Binding IsExpanded}"
+                                            Data="{x:Static suki:Icons.ChevronRight}"
+                                            Width="18"
+                                            Height="18" />
+
+                                        <!-- Row 0: Song info + expand toggle -->
+
+                                        <Border Grid.Row="0" Grid.Column="1" Width="60"
                                                 Height="60"
                                                 CornerRadius="12"
                                                 ClipToBounds="True"
@@ -180,7 +204,7 @@
                                                    Stretch="UniformToFill" />
                                         </Border>
 
-                                        <StackPanel Grid.Column="1"
+                                        <StackPanel Grid.Row="0" Grid.Column="2"
                                                     VerticalAlignment="Center"
                                                     Spacing="4">
                                             <TextBlock Text="{Binding Title}"
@@ -191,34 +215,72 @@
                                                        TextTrimming="CharacterEllipsis" />
                                         </StackPanel>
 
-                                        <TextBlock Grid.Column="2"
+                                        <TextBlock Grid.Row="0" Grid.Column="3"
                                                    Text="{Binding Album}"
                                                    VerticalAlignment="Center"
                                                    Foreground="{DynamicResource SukiLowText}"
                                                    TextTrimming="CharacterEllipsis" />
 
-                                        <TextBlock Grid.Column="3"
-                                                   Text="{Binding PlaylistName}"
-                                                   VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource SukiLowText}"
-                                                   TextTrimming="CharacterEllipsis" />
-
-                                        <TextBlock Grid.Column="4"
+                                        <TextBlock Grid.Row="0" Grid.Column="4"
                                                    Text="{Binding DurationSeconds, Converter={StaticResource SecondsToTimeConverter}}"
                                                    VerticalAlignment="Center"
                                                    Foreground="{DynamicResource SukiLowText}" />
 
-                                        <Button Grid.Column="5"
-                                                Classes="Basic"
-                                                HorizontalAlignment="Right"
-                                                VerticalAlignment="Center"
-                                                Cursor="Hand"
-                                                Command="{Binding #SearchDialogRoot.((vm:LocalMusicSearchDialogViewModel)DataContext).OpenResultCommand}"
-                                                CommandParameter="{Binding}">
-                                            <TextBlock Text="打开歌单" />
-                                        </Button>
+
+                                        <!-- Row 1: Expandable playlist list -->
+                                        <Grid Grid.Row="1"
+                                              Grid.ColumnSpan="5" Grid.Column="0"
+                                              IsVisible="{Binding IsExpanded}"
+                                              Margin="20,8,0,0">
+
+                                            <StackPanel IsVisible="{Binding IsLoadingPlaylists}"
+                                                        HorizontalAlignment="Center"
+                                                        Orientation="Horizontal"
+                                                        Spacing="8"
+                                                        Margin="8">
+                                                <suki:Loading Width="18" Height="18" />
+                                                <TextBlock Text="正在加载所在歌单..."
+                                                           Foreground="{DynamicResource SukiLowText}" />
+                                            </StackPanel>
+
+                                            <ListBox ItemsSource="{Binding Playlists}"
+                                                     IsVisible="{Binding !IsLoadingPlaylists}">
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate DataType="vm:PlaylistSummaryItem">
+                                                        <suki:GlassCard Padding="8,6"
+                                                                        CornerRadius="12"
+                                                                        IsInteractive="True"
+                                                                        Command="{Binding $parent[ListBox].((vm:GroupedSearchResultItemViewModel)DataContext).OpenPlaylistCommand}"
+                                                                        CommandParameter="{Binding .}"
+                                                                        Background="{DynamicResource SukiPrimaryColor0}"
+                                                                        Margin="0,0,0,6">
+                                                            <Grid ColumnDefinitions="36,*,Auto"
+                                                                  ColumnSpacing="10">
+                                                                <Border Width="36"
+                                                                        Height="36"
+                                                                        CornerRadius="8"
+                                                                        ClipToBounds="True"
+                                                                        Background="{DynamicResource SukiPrimaryColorLow}">
+                                                                    <Image
+                                                                        asyncImageLoader:ImageLoader.Source="{Binding PlaylistCover}"
+                                                                        Stretch="UniformToFill" />
+                                                                </Border>
+
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{Binding PlaylistName}"
+                                                                           VerticalAlignment="Center"
+                                                                           TextTrimming="CharacterEllipsis" />
+
+                                                                <Svg Grid.Column="2"
+                                                                     Path="avares://KugouAvaloniaPlayer/Assets/NavigateNext.svg" />
+                                                            </Grid>
+                                                        </suki:GlassCard>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                        </Grid>
                                     </Grid>
-                                </Border>
+                                </suki:GlassCard>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/LocalMusicSearchDialog.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace KugouAvaloniaPlayer.Controls;
+
+public partial class LocalMusicSearchDialog : UserControl
+{
+    public LocalMusicSearchDialog()
+    {
+        InitializeComponent();
+        AttachedToVisualTree += (_, _) => SearchBox.Focus();
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
@@ -22,6 +22,7 @@ public partial class SongCollectionDetailView : UserControl
 {
     private INotifyCollectionChanged? _songsCollectionNotifier;
     private PlayerViewModel? _subscribedPlayer;
+    private long _lastLocatedRequestSequence;
 
     public static readonly StyledProperty<string?> CoverProperty =
         AvaloniaProperty.Register<SongCollectionDetailView, string?>(nameof(Cover));
@@ -64,6 +65,9 @@ public partial class SongCollectionDetailView : UserControl
 
     public static readonly StyledProperty<IEnumerable?> SongsProperty =
         AvaloniaProperty.Register<SongCollectionDetailView, IEnumerable?>(nameof(Songs));
+
+    public static readonly StyledProperty<SongLocateRequest?> SongLocateRequestProperty =
+        AvaloniaProperty.Register<SongCollectionDetailView, SongLocateRequest?>(nameof(SongLocateRequest));
 
     public static readonly StyledProperty<ICommand?> LoadMoreCommandProperty =
         AvaloniaProperty.Register<SongCollectionDetailView, ICommand?>(nameof(LoadMoreCommand));
@@ -238,6 +242,12 @@ public partial class SongCollectionDetailView : UserControl
     {
         get => GetValue(SongsProperty);
         set => SetValue(SongsProperty, value);
+    }
+
+    public SongLocateRequest? SongLocateRequest
+    {
+        get => GetValue(SongLocateRequestProperty);
+        set => SetValue(SongLocateRequestProperty, value);
     }
 
     public ICommand? LoadMoreCommand
@@ -451,7 +461,11 @@ public partial class SongCollectionDetailView : UserControl
             DetachSongsCollectionChanged(change.OldValue as IEnumerable);
             AttachSongsCollectionChanged(change.NewValue as IEnumerable);
             SyncPlayingState();
+            ScheduleLocateRequestedSong();
         }
+
+        if (change.Property == SongLocateRequestProperty)
+            ScheduleLocateRequestedSong();
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -462,6 +476,7 @@ public partial class SongCollectionDetailView : UserControl
         AttachPlayerPropertyChanged();
         UpdateCurrentHeroBackground();
         SyncPlayingState();
+        ScheduleLocateRequestedSong();
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
@@ -561,6 +576,7 @@ public partial class SongCollectionDetailView : UserControl
     private void OnSongsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         SyncPlayingState();
+        ScheduleLocateRequestedSong();
     }
 
     private void OnPlayerPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -588,6 +604,30 @@ public partial class SongCollectionDetailView : UserControl
             Update();
         else
             Dispatcher.UIThread.Post(Update);
+    }
+
+    private void ScheduleLocateRequestedSong()
+    {
+        Dispatcher.UIThread.Post(TryLocateRequestedSong, DispatcherPriority.Loaded);
+    }
+
+    private void TryLocateRequestedSong()
+    {
+        var request = SongLocateRequest;
+        if (request is null || request.Sequence == _lastLocatedRequestSequence)
+            return;
+
+        var targetSong = Songs?
+            .AsValueEnumerable()
+            .OfType<SongItem>()
+            .FirstOrDefault(song => song.LocalTrackId == request.LocalTrackId);
+        if (targetSong is null)
+            return;
+
+        _lastLocatedRequestSequence = request.Sequence;
+        SongList.SelectedItem = targetSong;
+        SongList.ScrollIntoView(targetSong);
+        Dispatcher.UIThread.Post(() => AdjustScrollPosition(targetSong), DispatcherPriority.Background);
     }
 
 

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongListItemControl.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongListItemControl.axaml.cs
@@ -88,6 +88,15 @@ public partial class SongListItemControl : UserControl
                 CommandParameter = song
             });
         }
+        else
+        {
+            flyout.Items.Add(new MenuItem
+            {
+                Header = "查找所在歌单",
+                Command = song.SearchLocalPlaylistsCommand,
+                CommandParameter = song
+            });
+        }
 
         if (!includePlaylistSpecificItems)
             return;

--- a/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml
@@ -1,0 +1,155 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:KugouAvaloniaPlayer.ViewModels"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
+             xmlns:asyncImageLoader="clr-namespace:AsyncImageLoader;assembly=AsyncImageLoader.Avalonia"
+             x:Class="KugouAvaloniaPlayer.Controls.TrackPlaylistSearchDialog"
+             x:Name="SearchDialogRoot"
+             x:DataType="vm:TrackPlaylistSearchDialogViewModel">
+
+    <UserControl.Styles>
+        <Style Selector="ListBox.TrackPlaylistSearchList">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        </Style>
+
+        <Style Selector="ListBox.TrackPlaylistSearchList ListBoxItem">
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Padding="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      Background="Transparent" />
+                </ControlTemplate>
+            </Setter>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Width="920"
+            Padding="22"
+            Background="{DynamicResource SukiBackground}"
+            CornerRadius="18">
+        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
+            <StackPanel Spacing="6"
+                        Margin="0,0,0,16">
+                <TextBlock Text="精确歌单检索"
+                           FontSize="24"
+                           FontWeight="Bold" />
+            </StackPanel>
+
+            <suki:GlassCard Grid.Row="1"
+                            Padding="12"
+                            CornerRadius="14"
+                            Margin="0,0,0,16"
+                            Background="{DynamicResource SukiPrimaryColorLow}">
+                <Grid ColumnDefinitions="Auto,*,20,*">
+                    <Border Grid.Column="0"
+                            Width="54" Height="54"
+                            CornerRadius="10"
+                            ClipToBounds="True"
+                            Background="{DynamicResource SukiPrimaryColor0}">
+                        <Image asyncImageLoader:ImageLoader.Source="{Binding Cover}"
+                               Stretch="UniformToFill" />
+                    </Border>
+
+                    <StackPanel Grid.Column="1"
+                                VerticalAlignment="Center"
+                                Margin="14,0,0,0"
+                                Spacing="3">
+                        <TextBlock Text="{Binding Title}"
+                                   FontWeight="SemiBold"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis" />
+                        <TextBlock Text="{Binding Artist}"
+                                   TextWrapping="NoWrap"
+                                   Foreground="{DynamicResource SukiLowText}"
+                                   FontSize="12"
+                                   TextTrimming="CharacterEllipsis" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="3"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Right"
+                                Spacing="2">
+                        <TextBlock Text="{Binding Album}"
+                                   Foreground="{DynamicResource SukiLowText}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   HorizontalAlignment="Right" />
+                        <TextBlock Text="{Binding Duration, Converter={StaticResource SecondsToTimeConverter}}"
+                                   Foreground="{DynamicResource SukiLowText}"
+                                   TextWrapping="NoWrap"
+                                   FontSize="12"
+                                   HorizontalAlignment="Right" />
+                    </StackPanel>
+                </Grid>
+            </suki:GlassCard>
+
+            <TextBlock Grid.Row="2"
+                       Text="所在歌单"
+                       FontWeight="SemiBold"
+                       Foreground="{DynamicResource SukiLowText}"
+                       Margin="0,0,0,8" />
+
+            <ListBox Grid.Row="3"
+                     Classes="TrackPlaylistSearchList"
+                     ItemsSource="{Binding Playlists}"
+                     MaxHeight="340">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+                <ListBox.ItemTemplate>
+                    <DataTemplate DataType="vm:TrackPlaylistItem">
+                        <suki:GlassCard Padding="10,8"
+                                        CornerRadius="12"
+                                        IsInteractive="True"
+                                        Command="{Binding $parent[ListBox].((vm:TrackPlaylistSearchDialogViewModel)DataContext).OpenPlaylistCommand}"
+                                        CommandParameter="{Binding .}"
+                                        Background="{DynamicResource SukiPrimaryColor0}"
+                                        Margin="0,0,0,8">
+                            <Grid ColumnDefinitions="40,*,Auto"
+                                  ColumnSpacing="12">
+                                <Border Grid.Column="0"
+                                        Width="40" Height="40"
+                                        CornerRadius="8"
+                                        ClipToBounds="True"
+                                        Background="{DynamicResource SukiPrimaryColorLow}">
+                                    <Image asyncImageLoader:ImageLoader.Source="{Binding PlaylistCover}"
+                                           Stretch="UniformToFill" />
+                                </Border>
+
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding PlaylistName}"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis" />
+
+                                <Svg Grid.Column="2"
+                                     Path="avares://KugouAvaloniaPlayer/Assets/NavigateNext.svg" />
+                            </Grid>
+                        </suki:GlassCard>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <Button Grid.Row="4"
+                    Classes="Basic"
+                    Command="{Binding CancelCommand}"
+                    Cursor="Hand"
+                    HorizontalAlignment="Right"
+                    Margin="0,14,0,0">
+                <TextBlock Text="关闭" />
+            </Button>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace KugouAvaloniaPlayer.Controls;
+
+public partial class TrackPlaylistSearchDialog : UserControl
+{
+    public TrackPlaylistSearchDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/Models/Messages.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Models/Messages.cs
@@ -22,6 +22,8 @@ public record RemoveFromPlaylistMessage(SongItem Song);
 
 public record SetLocalSongCoverMessage(SongItem Song);
 
+public record SongLocateRequest(long LocalTrackId, long Sequence);
+
 public record AuthStateChangedMessage(bool IsLoggedIn);
 
 public record RequestNavigateBackMessage;

--- a/src/Apps/KugouAvaloniaPlayer/Models/Messages.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Models/Messages.cs
@@ -14,6 +14,8 @@ public record ShowSongBatchActionDialogMessage(IReadOnlyList<SongItem> Songs, bo
 
 public record ShowPlaylistDialogMessage(SongItem Song);
 
+public record ShowTrackPlaylistSearchDialogMessage(SongItem Song);
+
 public record ReplacePlaybackQueueMessage(IReadOnlyList<SongItem> Songs, SongItem? StartSong = null);
 
 public record NavigateToSingerMessage(SingerLite Singer);

--- a/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
@@ -75,6 +75,7 @@ public sealed partial class AvaloniaAppServiceProvider
         .Bind<IFolderPickerService>().As(Singleton).To<FolderPickerService>()
         .Bind<IJellyfinClient>().As(Singleton).To<JellyfinClient>()
         .Bind<ILocalMusicLibraryService>().As(Singleton).To<LocalMusicLibraryService>()
+        .Bind<ILocalMusicSearchDialogService>().As(Singleton).To<LocalMusicSearchDialogService>()
         .Bind<IGitHubReleaseService>().As(Singleton).To<GitHubReleaseService>()
         .Bind<IAppUpdateService>().As(Singleton).To<AppUpdateService>()
         .Bind<ISingerViewModelFactory>().To<SingerViewModelFactory>()

--- a/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
@@ -76,6 +76,7 @@ public sealed partial class AvaloniaAppServiceProvider
         .Bind<IJellyfinClient>().As(Singleton).To<JellyfinClient>()
         .Bind<ILocalMusicLibraryService>().As(Singleton).To<LocalMusicLibraryService>()
         .Bind<ILocalMusicSearchDialogService>().As(Singleton).To<LocalMusicSearchDialogService>()
+        .Bind<ITrackPlaylistSearchDialogService>().As(Singleton).To<TrackPlaylistSearchDialogService>()
         .Bind<IGitHubReleaseService>().As(Singleton).To<GitHubReleaseService>()
         .Bind<IAppUpdateService>().As(Singleton).To<AppUpdateService>()
         .Bind<ISingerViewModelFactory>().To<SingerViewModelFactory>()

--- a/src/Apps/KugouAvaloniaPlayer/Services/FavoritePlaylistService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/FavoritePlaylistService.cs
@@ -487,6 +487,10 @@ public partial class FavoritePlaylistService(
 
             if (response.Status != 1)
             {
+                if (response.ErrorCode == 30227) {
+                    ShowToast(NotificationType.Error,"歌单未初始化","请下载并登录酷狗音乐APP以初始化歌单信息。");
+                    return [];
+                }
                 logger.LogError("获取歌单列表失败 err_code={ErrorCode}, page={Page}", response.ErrorCode, page);
                 return null;
             }
@@ -638,7 +642,7 @@ public partial class FavoritePlaylistService(
                 AlbumId = song.AlbumId,
                 Cover = song.Cover,
                 DurationSeconds = song.DurationSeconds,
-                Singers = song.Singers?.AsValueEnumerable().ToList() ?? new List<SingerLite>()
+                Singers = song.Singers.AsValueEnumerable().ToList()
             });
         }
     }

--- a/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicLibraryService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicLibraryService.cs
@@ -22,6 +22,9 @@ public interface ILocalMusicLibraryService
     Task InitializeAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LocalPlaylistSummary>> GetPlaylistsAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LocalTrackItem>> GetPlaylistTracksAsync(long playlistId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LocalTrackSearchResult>> SearchTracksAsync(
+        string keyword,
+        CancellationToken cancellationToken = default);
     Task<LocalPlaylistSummary> CreatePlaylistAsync(string name, CancellationToken cancellationToken = default);
     Task<LocalPlaylistSummary> ImportFolderAsync(string folderPath, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LocalPlaylistSummary>> ImportJellyfinLibraryAsync(
@@ -54,6 +57,12 @@ public sealed record LocalTrackItem(
     string LocalPath,
     string? CoverPath,
     string? RemoteUrl);
+
+public sealed record LocalTrackSearchResult(
+    LocalTrackItem Track,
+    long PlaylistId,
+    string PlaylistName,
+    int PlaylistPosition);
 
 public sealed class LocalMusicLibraryService(
     IJellyfinClient jellyfinClient,
@@ -139,6 +148,60 @@ public sealed class LocalMusicLibraryService(
             tracks.Add(ReadTrackItem(reader));
 
         return tracks;
+    }
+
+    public async Task<IReadOnlyList<LocalTrackSearchResult>> SearchTracksAsync(
+        string keyword,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedKeyword = keyword.Trim();
+        if (normalizedKeyword.Length == 0)
+            return [];
+
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path,
+                   t.cover_path, t.remote_url, p.id AS playlist_id, p.name AS playlist_name,
+                   pt.position AS playlist_position
+            FROM playlist_tracks pt
+            INNER JOIN tracks t ON t.id = pt.track_id
+            INNER JOIN playlists p ON p.id = pt.playlist_id
+            WHERE t.title LIKE $pattern ESCAPE '\'
+               OR t.artist LIKE $pattern ESCAPE '\'
+               OR t.album LIKE $pattern ESCAPE '\'
+               OR p.name LIKE $pattern ESCAPE '\'
+            ORDER BY
+                CASE
+                    WHEN t.title = $keyword COLLATE NOCASE THEN 0
+                    WHEN t.title LIKE $prefix ESCAPE '\' THEN 1
+                    ELSE 2
+                END,
+                t.title COLLATE NOCASE,
+                p.name COLLATE NOCASE,
+                pt.position,
+                t.id;
+            """;
+
+        var escapedKeyword = EscapeLikePattern(normalizedKeyword);
+        command.Parameters.AddWithValue("$keyword", normalizedKeyword);
+        command.Parameters.AddWithValue("$prefix", escapedKeyword + "%");
+        command.Parameters.AddWithValue("$pattern", "%" + escapedKeyword + "%");
+
+        var results = new List<LocalTrackSearchResult>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(new LocalTrackSearchResult(
+                ReadTrackItem(reader),
+                reader.GetInt64(reader.GetOrdinal("playlist_id")),
+                reader.GetString(reader.GetOrdinal("playlist_name")),
+                reader.GetInt32(reader.GetOrdinal("playlist_position"))));
+        }
+
+        return results;
     }
 
     public async Task<LocalPlaylistSummary> CreatePlaylistAsync(string name, CancellationToken cancellationToken = default)
@@ -1257,6 +1320,14 @@ public sealed class LocalMusicLibraryService(
     private static object DbValue(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value;
+    }
+
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace(@"\", @"\\", StringComparison.Ordinal)
+            .Replace("%", @"\%", StringComparison.Ordinal)
+            .Replace("_", @"\_", StringComparison.Ordinal);
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)

--- a/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicLibraryService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicLibraryService.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using ATL;
-using Avalonia.Media.Imaging;
 using KugouAvaloniaPlayer.Converters;
 using KugouAvaloniaPlayer.Models;
 using KugouAvaloniaPlayer.Services.Jellyfin;
@@ -17,35 +16,56 @@ using Microsoft.Extensions.Logging;
 
 namespace KugouAvaloniaPlayer.Services;
 
-public interface ILocalMusicLibraryService
-{
+public interface ILocalMusicLibraryService {
     Task InitializeAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LocalPlaylistSummary>> GetPlaylistsAsync(CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<LocalTrackItem>> GetPlaylistTracksAsync(long playlistId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LocalTrackItem>> GetPlaylistTracksAsync(
+        long playlistId,
+        CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<LocalTrackSearchResult>> SearchTracksAsync(
         string keyword,
         CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LocalTrackSearchResult>> SearchDistinctTracksAsync(
+        string keyword,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LocalPlaylistSummary>> GetTrackPlaylistsAsync(
+        long trackId,
+        CancellationToken cancellationToken = default);
+
     Task<LocalPlaylistSummary> CreatePlaylistAsync(string name, CancellationToken cancellationToken = default);
     Task<LocalPlaylistSummary> ImportFolderAsync(string folderPath, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<LocalPlaylistSummary>> ImportJellyfinLibraryAsync(
         JellyfinConnectionOptions options,
         JellyfinLibrary library,
         IProgress<JellyfinImportProgress>? progress = null,
         CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<LocalPlaylistSummary>> RefreshImportedLibrariesAsync(CancellationToken cancellationToken = default);
-    Task AddFilesToPlaylistAsync(long playlistId, IEnumerable<string> filePaths, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LocalPlaylistSummary>> RefreshImportedLibrariesAsync(
+        CancellationToken cancellationToken = default);
+
+    Task AddFilesToPlaylistAsync(
+        long playlistId,
+        IEnumerable<string> filePaths,
+        CancellationToken cancellationToken = default);
+
     Task RemoveTrackFromPlaylistAsync(long playlistId, long trackId, CancellationToken cancellationToken = default);
-    Task UpdatePlaylistAsync(long playlistId, string name, string? coverPath, CancellationToken cancellationToken = default);
+
+    Task UpdatePlaylistAsync(
+        long playlistId,
+        string name,
+        string? coverPath,
+        CancellationToken cancellationToken = default);
+
     Task DeletePlaylistAsync(long playlistId, CancellationToken cancellationToken = default);
     Task SetTrackCoverAsync(long trackId, string coverPath, CancellationToken cancellationToken = default);
 }
 
-public sealed record LocalPlaylistSummary(
-    long Id,
-    string Name,
-    string? CoverPath,
-    int TrackCount,
-    DateTime UpdatedAt);
+public sealed record LocalPlaylistSummary(long Id, string Name, string? CoverPath, int TrackCount, DateTime UpdatedAt);
 
 public sealed record LocalTrackItem(
     long Id,
@@ -64,82 +84,72 @@ public sealed record LocalTrackSearchResult(
     string PlaylistName,
     int PlaylistPosition);
 
-public sealed class LocalMusicLibraryService(
-    IJellyfinClient jellyfinClient,
-    ILogger<LocalMusicLibraryService> logger) : ILocalMusicLibraryService
-{
+public sealed class LocalMusicLibraryService(IJellyfinClient jellyfinClient, ILogger<LocalMusicLibraryService> logger)
+    : ILocalMusicLibraryService {
     private const string PlaylistKindManual = "Manual";
     private const string PlaylistKindImportedFolder = "ImportedFolder";
     private const string PlaylistKindJellyfinLibrary = "JellyfinLibrary";
     private const string SourceTypeLocalFile = "LocalFile";
     private const int LocalImportBatchSize = 32;
-    private const string EmbeddedCoverCacheVersion = "thumb-v1";
-    private const int EmbeddedCoverThumbnailWidth = 512;
-    private const int EmbeddedCoverJpegQuality = 86;
-    private const long MaxLocalSongCoverCacheBytes = 256L * 1024 * 1024;
     public const string SourceTypeJellyfin = "Jellyfin";
 
-    private static readonly string LocalSongCoverCacheDirectory = Path.Combine(
+    private static readonly string _localSongCoverCacheDirectory = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "kugou",
         "local-song-covers");
 
-    private static readonly HashSet<string> SupportedLocalAudioExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".ape",
-        ".mp3",
-        ".flac",
-        ".wav",
-        ".ogg",
-        ".m4a",
-        ".aac",
-        ".webm",
-        ".dsf",
-        ".dff"
-    };
+    private static readonly HashSet<string> _supportedLocalAudioExtensions =
+        new(StringComparer.OrdinalIgnoreCase) {
+            ".ape",
+            ".mp3",
+            ".flac",
+            ".wav",
+            ".ogg",
+            ".m4a",
+            ".aac",
+            ".webm",
+            ".dsf",
+            ".dff"
+        };
 
     private readonly SemaphoreSlim _gate = new(1, 1);
     private bool _initialized;
 
-    public async Task InitializeAsync(CancellationToken cancellationToken = default)
-    {
+    public async Task InitializeAsync(CancellationToken cancellationToken = default) {
         await _gate.WaitAsync(cancellationToken);
-        try
-        {
+        try {
             if (_initialized)
                 return;
 
             AppDatabase.EnsureDatabaseCreated();
             _initialized = true;
-        }
-        finally
-        {
+        } finally {
             _gate.Release();
         }
 
         await ImportLegacyJsonAsync(cancellationToken);
     }
 
-    public async Task<IReadOnlyList<LocalPlaylistSummary>> GetPlaylistsAsync(CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<LocalPlaylistSummary>> GetPlaylistsAsync(
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         return await GetPlaylistSummariesAsync(connection, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<LocalTrackItem>> GetPlaylistTracksAsync(long playlistId, CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<LocalTrackItem>> GetPlaylistTracksAsync(
+        long playlistId,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            SELECT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path, t.cover_path, t.remote_url
-            FROM playlist_tracks pt
-            INNER JOIN tracks t ON t.id = pt.track_id
-            WHERE pt.playlist_id = $playlistId
-            ORDER BY pt.position, pt.added_at, pt.track_id;
-            """;
+        command.CommandText = """
+                              SELECT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path, t.cover_path, t.remote_url
+                              FROM playlist_tracks pt
+                              INNER JOIN tracks t ON t.id = pt.track_id
+                              WHERE pt.playlist_id = $playlistId
+                              ORDER BY pt.position, pt.added_at, pt.track_id;
+                              """;
         command.Parameters.AddWithValue("$playlistId", playlistId);
 
         var tracks = new List<LocalTrackItem>();
@@ -152,8 +162,7 @@ public sealed class LocalMusicLibraryService(
 
     public async Task<IReadOnlyList<LocalTrackSearchResult>> SearchTracksAsync(
         string keyword,
-        CancellationToken cancellationToken = default)
-    {
+        CancellationToken cancellationToken = default) {
         var normalizedKeyword = keyword.Trim();
         if (normalizedKeyword.Length == 0)
             return [];
@@ -161,29 +170,28 @@ public sealed class LocalMusicLibraryService(
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            SELECT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path,
-                   t.cover_path, t.remote_url, p.id AS playlist_id, p.name AS playlist_name,
-                   pt.position AS playlist_position
-            FROM playlist_tracks pt
-            INNER JOIN tracks t ON t.id = pt.track_id
-            INNER JOIN playlists p ON p.id = pt.playlist_id
-            WHERE t.title LIKE $pattern ESCAPE '\'
-               OR t.artist LIKE $pattern ESCAPE '\'
-               OR t.album LIKE $pattern ESCAPE '\'
-               OR p.name LIKE $pattern ESCAPE '\'
-            ORDER BY
-                CASE
-                    WHEN t.title = $keyword COLLATE NOCASE THEN 0
-                    WHEN t.title LIKE $prefix ESCAPE '\' THEN 1
-                    ELSE 2
-                END,
-                t.title COLLATE NOCASE,
-                p.name COLLATE NOCASE,
-                pt.position,
-                t.id;
-            """;
+        command.CommandText = """
+                              SELECT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path,
+                                     t.cover_path, t.remote_url, p.id AS playlist_id, p.name AS playlist_name,
+                                     pt.position AS playlist_position
+                              FROM playlist_tracks pt
+                              INNER JOIN tracks t ON t.id = pt.track_id
+                              INNER JOIN playlists p ON p.id = pt.playlist_id
+                              WHERE t.title LIKE $pattern ESCAPE '\'
+                                 OR t.artist LIKE $pattern ESCAPE '\'
+                                 OR t.album LIKE $pattern ESCAPE '\'
+                                 OR p.name LIKE $pattern ESCAPE '\'
+                              ORDER BY
+                                  CASE
+                                      WHEN t.title = $keyword COLLATE NOCASE THEN 0
+                                      WHEN t.title LIKE $prefix ESCAPE '\' THEN 1
+                                      ELSE 2
+                                  END,
+                                  t.title COLLATE NOCASE,
+                                  p.name COLLATE NOCASE,
+                                  pt.position,
+                                  t.id;
+                              """;
 
         var escapedKeyword = EscapeLikePattern(normalizedKeyword);
         command.Parameters.AddWithValue("$keyword", normalizedKeyword);
@@ -192,25 +200,99 @@ public sealed class LocalMusicLibraryService(
 
         var results = new List<LocalTrackSearchResult>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
-        {
-            results.Add(new LocalTrackSearchResult(
-                ReadTrackItem(reader),
-                reader.GetInt64(reader.GetOrdinal("playlist_id")),
-                reader.GetString(reader.GetOrdinal("playlist_name")),
-                reader.GetInt32(reader.GetOrdinal("playlist_position"))));
+        while (await reader.ReadAsync(cancellationToken)) {
+            results.Add(
+                new LocalTrackSearchResult(
+                    ReadTrackItem(reader),
+                    reader.GetInt64(reader.GetOrdinal("playlist_id")),
+                    reader.GetString(reader.GetOrdinal("playlist_name")),
+                    reader.GetInt32(reader.GetOrdinal("playlist_position"))));
         }
 
         return results;
     }
 
-    public async Task<LocalPlaylistSummary> CreatePlaylistAsync(string name, CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<LocalTrackSearchResult>> SearchDistinctTracksAsync(
+        string keyword,
+        CancellationToken cancellationToken = default) {
+        var normalizedKeyword = keyword.Trim();
+        if (normalizedKeyword.Length == 0)
+            return [];
+
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT DISTINCT t.id, t.title, t.artist, t.album, t.duration_seconds, t.source_type, t.local_path,
+                                     t.cover_path, t.remote_url
+                              FROM tracks t
+                              LEFT JOIN playlist_tracks pt ON pt.track_id = t.id
+                              LEFT JOIN playlists p ON p.id = pt.playlist_id
+                              WHERE t.title LIKE $pattern ESCAPE '\'
+                                 OR t.artist LIKE $pattern ESCAPE '\'
+                                 OR t.album LIKE $pattern ESCAPE '\'
+                                 OR p.name LIKE $pattern ESCAPE '\'
+                              ORDER BY
+                                  CASE
+                                      WHEN t.title = $keyword COLLATE NOCASE THEN 0
+                                      WHEN t.title LIKE $prefix ESCAPE '\' THEN 1
+                                      ELSE 2
+                                  END,
+                                  t.title COLLATE NOCASE,
+                                  t.id;
+                              """;
+
+        var escapedKeyword = EscapeLikePattern(normalizedKeyword);
+        command.Parameters.AddWithValue("$keyword", normalizedKeyword);
+        command.Parameters.AddWithValue("$prefix", escapedKeyword + "%");
+        command.Parameters.AddWithValue("$pattern", "%" + escapedKeyword + "%");
+
+        // Returns LocalTrackSearchResult with placeholder playlist info (will be fetched on expand)
+        var results = new List<LocalTrackSearchResult>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken)) {
+            results.Add(
+                new LocalTrackSearchResult(
+                    ReadTrackItem(reader),
+                    0,            // PlaylistId — placeholder, real playlists loaded on expand
+                    string.Empty, // PlaylistName — placeholder
+                    0));          // PlaylistPosition — placeholder
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<LocalPlaylistSummary>> GetTrackPlaylistsAsync(
+        long trackId,
+        CancellationToken cancellationToken = default) {
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT p.id, p.name, p.cover_path, p.updated_at,
+                                     (SELECT COUNT(*) FROM playlist_tracks pt2 WHERE pt2.playlist_id = p.id) AS track_count
+                              FROM playlist_tracks pt
+                              INNER JOIN playlists p ON p.id = pt.playlist_id
+                              WHERE pt.track_id = $trackId
+                              ORDER BY p.updated_at DESC, p.id DESC;
+                              """;
+        command.Parameters.AddWithValue("$trackId", trackId);
+
+        var playlists = new List<LocalPlaylistSummary>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+            playlists.Add(ReadPlaylistSummary(reader));
+
+        return playlists;
+    }
+
+    public async Task<LocalPlaylistSummary> CreatePlaylistAsync(
+        string name,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         var now = DateTime.UtcNow;
-        var playlist = new LocalPlaylistEntity
-        {
+        var playlist = new LocalPlaylistEntity {
             Name = string.IsNullOrWhiteSpace(name) ? "新建本地歌单" : name.Trim(),
             Kind = PlaylistKindManual,
             CreatedAtUtc = now,
@@ -225,20 +307,19 @@ public sealed class LocalMusicLibraryService(
         JellyfinConnectionOptions options,
         JellyfinLibrary library,
         IProgress<JellyfinImportProgress>? progress = null,
-        CancellationToken cancellationToken = default)
-    {
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
 
         var serverFingerprint = jellyfinClient.GetServerFingerprint(options.ServerUrl);
         var audioItems = await jellyfinClient.GetAudioItemsAsync(options, library.Id, progress, cancellationToken);
-        var albumGroups = audioItems
-            .AsValueEnumerable().GroupBy(GetJellyfinAlbumKey)
-            .Select(x => new JellyfinAlbumGroup(
-                x.Key,
-                GetJellyfinAlbumName(x.AsValueEnumerable().First()),
-                x.AsValueEnumerable().ToList()))
-            .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
-            .ToList();
+        var albumGroups = audioItems.AsValueEnumerable()
+                                    .GroupBy(GetJellyfinAlbumKey)
+                                    .Select(x => new JellyfinAlbumGroup(
+                                                x.Key,
+                                                GetJellyfinAlbumName(x.AsValueEnumerable().First()),
+                                                x.AsValueEnumerable().ToList()))
+                                    .OrderBy(x => x.Name, StringComparer.CurrentCultureIgnoreCase)
+                                    .ToList();
 
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         await using var transaction = connection.BeginTransaction();
@@ -250,16 +331,14 @@ public sealed class LocalMusicLibraryService(
             PlaylistKindJellyfinLibrary,
             legacyLibrarySourceRef,
             cancellationToken);
-        if (legacyLibraryPlaylist != null)
-        {
+        if (legacyLibraryPlaylist != null) {
             await DeletePlaylistAsync(connection, transaction, legacyLibraryPlaylist.Id, cancellationToken);
         }
 
         var importedPlaylistIds = new List<long>();
         var importedSourceRefs = new HashSet<string>(StringComparer.Ordinal);
         var processedSongs = 0;
-        foreach (var albumGroup in albumGroups)
-        {
+        foreach (var albumGroup in albumGroups) {
             var sourceRef = serverFingerprint + ":" + library.Id + ":" + albumGroup.Key;
             importedSourceRefs.Add(sourceRef);
             var playlist = await FindPlaylistAsync(
@@ -269,11 +348,9 @@ public sealed class LocalMusicLibraryService(
                 sourceRef,
                 cancellationToken);
 
-            if (playlist == null)
-            {
+            if (playlist == null) {
                 var now = DateTime.UtcNow;
-                playlist = new LocalPlaylistEntity
-                {
+                playlist = new LocalPlaylistEntity {
                     Name = albumGroup.Name,
                     Kind = PlaylistKindJellyfinLibrary,
                     SourceRef = sourceRef,
@@ -281,9 +358,7 @@ public sealed class LocalMusicLibraryService(
                     UpdatedAtUtc = now
                 };
                 playlist.Id = await InsertPlaylistAsync(connection, transaction, playlist, cancellationToken);
-            }
-            else
-            {
+            } else {
                 playlist.Name = albumGroup.Name;
                 playlist.UpdatedAtUtc = DateTime.UtcNow;
                 await UpdatePlaylistAsync(connection, transaction, playlist, cancellationToken);
@@ -291,26 +366,34 @@ public sealed class LocalMusicLibraryService(
 
             await DeletePlaylistTracksAsync(connection, transaction, playlist.Id, cancellationToken);
 
-            for (var i = 0; i < albumGroup.Items.Count; i++)
-            {
+            for (var i = 0; i < albumGroup.Items.Count; i++) {
                 var track = await UpsertJellyfinTrackAsync(
                     connection,
                     transaction,
                     serverFingerprint,
                     albumGroup.Items[i],
                     cancellationToken);
-                await InsertPlaylistTrackAsync(connection, transaction, playlist.Id, track.Id, i, DateTime.UtcNow, cancellationToken);
+                await InsertPlaylistTrackAsync(
+                    connection,
+                    transaction,
+                    playlist.Id,
+                    track.Id,
+                    i,
+                    DateTime.UtcNow,
+                    cancellationToken);
 
                 processedSongs++;
-                progress?.Report(new JellyfinImportProgress
-                {
-                    Processed = processedSongs,
-                    Total = audioItems.Count,
-                    Message = $"正在按专辑写入本地音乐库 {processedSongs}/{audioItems.Count}"
-                });
+                progress?.Report(
+                    new JellyfinImportProgress {
+                        Processed = processedSongs,
+                        Total = audioItems.Count,
+                        Message = $"正在按专辑写入本地音乐库 {processedSongs}/{audioItems.Count}"
+                    });
             }
 
-            playlist.CoverPath = albumGroup.Items.AsValueEnumerable().FirstOrDefault(x => !string.IsNullOrWhiteSpace(x.CoverUrl))?.CoverUrl;
+            playlist.CoverPath = albumGroup.Items.AsValueEnumerable()
+                                           .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x.CoverUrl))
+                                           ?.CoverUrl;
             playlist.UpdatedAtUtc = DateTime.UtcNow;
             await UpdatePlaylistAsync(connection, transaction, playlist, cancellationToken);
             importedPlaylistIds.Add(playlist.Id);
@@ -335,8 +418,8 @@ public sealed class LocalMusicLibraryService(
         return summaries;
     }
 
-    public async Task<IReadOnlyList<LocalPlaylistSummary>> RefreshImportedLibrariesAsync(CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<LocalPlaylistSummary>> RefreshImportedLibrariesAsync(
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
 
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
@@ -344,11 +427,9 @@ public sealed class LocalMusicLibraryService(
         var jellyfinLibraries = await GetImportedJellyfinLibrariesAsync(connection, cancellationToken);
 
         var refreshed = new List<LocalPlaylistSummary>();
-        foreach (var folderPath in folderPaths)
-        {
+        foreach (var folderPath in folderPaths) {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!Directory.Exists(folderPath))
-            {
+            if (!Directory.Exists(folderPath)) {
                 logger.LogWarning("刷新本地音乐库时跳过不存在的文件夹。 folder={Folder}", folderPath);
                 continue;
             }
@@ -356,11 +437,9 @@ public sealed class LocalMusicLibraryService(
             refreshed.Add(await ImportFolderAsync(folderPath, cancellationToken));
         }
 
-        foreach (var library in jellyfinLibraries)
-        {
+        foreach (var library in jellyfinLibraries) {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!SettingsManager.Settings.JellyfinServers.TryGetValue(library.ServerFingerprint, out var settings))
-            {
+            if (!SettingsManager.Settings.JellyfinServers.TryGetValue(library.ServerFingerprint, out var settings)) {
                 logger.LogWarning(
                     "刷新 Jellyfin 音乐库时找不到服务器配置。 fingerprint={Fingerprint} libraryId={LibraryId}",
                     library.ServerFingerprint,
@@ -369,18 +448,20 @@ public sealed class LocalMusicLibraryService(
             }
 
             var options = new JellyfinConnectionOptions(settings.ServerUrl, settings.UserId, settings.ApiKey);
-            refreshed.AddRange(await ImportJellyfinLibraryAsync(
-                options,
-                new JellyfinLibrary(library.LibraryId, "Jellyfin 音乐库"),
-                null,
-                cancellationToken));
+            refreshed.AddRange(
+                await ImportJellyfinLibraryAsync(
+                    options,
+                    new JellyfinLibrary(library.LibraryId, "Jellyfin 音乐库"),
+                    null,
+                    cancellationToken));
         }
 
         return refreshed;
     }
 
-    public async Task<LocalPlaylistSummary> ImportFolderAsync(string folderPath, CancellationToken cancellationToken = default)
-    {
+    public async Task<LocalPlaylistSummary> ImportFolderAsync(
+        string folderPath,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         if (!Directory.Exists(folderPath))
             throw new DirectoryNotFoundException(folderPath);
@@ -395,21 +476,25 @@ public sealed class LocalMusicLibraryService(
             folderPath,
             cancellationToken);
 
-        if (playlist == null)
-        {
+        if (playlist == null) {
             var now = DateTime.UtcNow;
-            playlist = new LocalPlaylistEntity
-            {
+            playlist = new LocalPlaylistEntity {
                 Name = new DirectoryInfo(folderPath).Name,
                 Kind = PlaylistKindImportedFolder,
                 SourceRef = folderPath,
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now
             };
-                playlist.Id = await InsertPlaylistAsync(connection, transaction, playlist, cancellationToken);
+            playlist.Id = await InsertPlaylistAsync(connection, transaction, playlist, cancellationToken);
         }
 
-        await ReplacePlaylistTracksFromFolderAsync(connection, transaction, playlist.Id, folderPath, null, cancellationToken);
+        await ReplacePlaylistTracksFromFolderAsync(
+            connection,
+            transaction,
+            playlist.Id,
+            folderPath,
+            null,
+            cancellationToken);
         playlist.UpdatedAtUtc = DateTime.UtcNow;
         await UpdatePlaylistAsync(connection, transaction, playlist, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
@@ -417,10 +502,15 @@ public sealed class LocalMusicLibraryService(
         return await GetPlaylistSummaryAsync(connection, null, playlist.Id, cancellationToken);
     }
 
-    public async Task AddFilesToPlaylistAsync(long playlistId, IEnumerable<string> filePaths, CancellationToken cancellationToken = default)
-    {
+    public async Task AddFilesToPlaylistAsync(
+        long playlistId,
+        IEnumerable<string> filePaths,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
-        var files = filePaths.AsValueEnumerable().Where(IsSupportedAudioFile).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var files = filePaths.AsValueEnumerable()
+                             .Where(IsSupportedAudioFile)
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .ToList();
         if (files.Count == 0)
             return;
 
@@ -432,13 +522,19 @@ public sealed class LocalMusicLibraryService(
         await using var transaction = connection.BeginTransaction();
         var existingTrackIds = await GetPlaylistTrackIdsAsync(connection, transaction, playlist.Id, cancellationToken);
         var position = await GetNextPlaylistPositionAsync(connection, transaction, playlist.Id, cancellationToken);
-        for (var i = 0; i < files.Count; i++)
-        {
+        for (var i = 0; i < files.Count; i++) {
             var track = await UpsertTrackAsync(connection, transaction, files[i], null, cancellationToken);
             if (existingTrackIds.Contains(track.Id))
                 continue;
 
-            await InsertPlaylistTrackAsync(connection, transaction, playlist.Id, track.Id, position + i, DateTime.UtcNow, cancellationToken);
+            await InsertPlaylistTrackAsync(
+                connection,
+                transaction,
+                playlist.Id,
+                track.Id,
+                position + i,
+                DateTime.UtcNow,
+                cancellationToken);
             existingTrackIds.Add(track.Id);
         }
 
@@ -447,8 +543,10 @@ public sealed class LocalMusicLibraryService(
         await transaction.CommitAsync(cancellationToken);
     }
 
-    public async Task RemoveTrackFromPlaylistAsync(long playlistId, long trackId, CancellationToken cancellationToken = default)
-    {
+    public async Task RemoveTrackFromPlaylistAsync(
+        long playlistId,
+        long trackId,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         var playlist = await GetPlaylistAsync(connection, null, playlistId, cancellationToken);
@@ -457,8 +555,7 @@ public sealed class LocalMusicLibraryService(
 
         await using var transaction = connection.BeginTransaction();
         var removed = await DeletePlaylistTrackAsync(connection, transaction, playlistId, trackId, cancellationToken);
-        if (removed == 0)
-        {
+        if (removed == 0) {
             await transaction.RollbackAsync(cancellationToken);
             return;
         }
@@ -468,8 +565,11 @@ public sealed class LocalMusicLibraryService(
         await transaction.CommitAsync(cancellationToken);
     }
 
-    public async Task UpdatePlaylistAsync(long playlistId, string name, string? coverPath, CancellationToken cancellationToken = default)
-    {
+    public async Task UpdatePlaylistAsync(
+        long playlistId,
+        string name,
+        string? coverPath,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         var playlist = await GetPlaylistAsync(connection, null, playlistId, cancellationToken);
@@ -482,8 +582,7 @@ public sealed class LocalMusicLibraryService(
         await UpdatePlaylistAsync(connection, null, playlist, cancellationToken);
     }
 
-    public async Task DeletePlaylistAsync(long playlistId, CancellationToken cancellationToken = default)
-    {
+    public async Task DeletePlaylistAsync(long playlistId, CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         var playlist = await GetPlaylistAsync(connection, null, playlistId, cancellationToken);
@@ -493,8 +592,10 @@ public sealed class LocalMusicLibraryService(
         await DeletePlaylistAsync(connection, null, playlist.Id, cancellationToken);
     }
 
-    public async Task SetTrackCoverAsync(long trackId, string coverPath, CancellationToken cancellationToken = default)
-    {
+    public async Task SetTrackCoverAsync(
+        long trackId,
+        string coverPath,
+        CancellationToken cancellationToken = default) {
         await EnsureInitializedAsync(cancellationToken);
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         var track = await GetTrackAsync(connection, null, trackId, cancellationToken);
@@ -503,49 +604,38 @@ public sealed class LocalMusicLibraryService(
 
         if (!string.Equals(track.SourceType, SourceTypeLocalFile, StringComparison.Ordinal) ||
             string.IsNullOrWhiteSpace(track.LocalPath) ||
-            !System.IO.File.Exists(track.LocalPath))
-        {
+            !File.Exists(track.LocalPath)) {
             throw new InvalidOperationException("只有本地音频文件支持写入嵌入封面。");
         }
 
         await WriteEmbeddedCoverAsync(track.LocalPath, coverPath, cancellationToken);
 
         track.CoverPath = LocalImageSourceHelper.BuildEmbeddedCoverSource(track.LocalPath);
-        track.LastWriteTimeUtc = System.IO.File.GetLastWriteTimeUtc(track.LocalPath);
+        track.LastWriteTimeUtc = File.GetLastWriteTimeUtc(track.LocalPath);
         track.UpdatedAtUtc = DateTime.UtcNow;
         await UpdateTrackAsync(connection, null, track, cancellationToken);
     }
 
-    private async Task ImportLegacyJsonAsync(CancellationToken cancellationToken)
-    {
-        SettingsManager.Settings.LocalMusicFolders ??= new List<string>();
-        SettingsManager.Settings.LocalPlaylistMetas ??= new Dictionary<string, LocalPlaylistMeta>();
-
+    private async Task ImportLegacyJsonAsync(CancellationToken cancellationToken) {
         var folders = SettingsManager.Settings.LocalMusicFolders.AsValueEnumerable().ToList();
         if (folders.Count == 0)
             return;
 
         var migrated = false;
-        foreach (var folder in folders)
-        {
+        foreach (var folder in folders) {
             cancellationToken.ThrowIfCancellationRequested();
             if (!Directory.Exists(folder))
                 continue;
 
-            try
-            {
-                var meta = SettingsManager.Settings.LocalPlaylistMetas.TryGetValue(folder, out var value) ? value : null;
+            try {
+                var meta = SettingsManager.Settings.LocalPlaylistMetas.GetValueOrDefault(folder);
                 await ImportLegacyFolderAsync(folder, meta, cancellationToken);
                 SettingsManager.Settings.LocalMusicFolders.Remove(folder);
                 SettingsManager.Settings.LocalPlaylistMetas.Remove(folder);
                 migrated = true;
-            }
-            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-            {
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) {
                 logger.LogWarning(ex, "迁移旧本地歌单失败，保留旧 JSON 条目。 folder={Folder}", folder);
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 logger.LogError(ex, "迁移旧本地歌单发生异常，保留旧 JSON 条目。 folder={Folder}", folder);
             }
         }
@@ -554,8 +644,10 @@ public sealed class LocalMusicLibraryService(
             SettingsManager.Save();
     }
 
-    private async Task ImportLegacyFolderAsync(string folderPath, LocalPlaylistMeta? meta, CancellationToken cancellationToken)
-    {
+    private async Task ImportLegacyFolderAsync(
+        string folderPath,
+        LocalPlaylistMeta? meta,
+        CancellationToken cancellationToken) {
         await using var connection = await AppDatabase.CreateConnectionAsync(cancellationToken);
         await using var transaction = connection.BeginTransaction();
 
@@ -566,29 +658,31 @@ public sealed class LocalMusicLibraryService(
             folderPath,
             cancellationToken);
 
-        if (playlist == null)
-        {
+        if (playlist == null) {
             var now = DateTime.UtcNow;
-            playlist = new LocalPlaylistEntity
-            {
-                Name = string.IsNullOrWhiteSpace(meta?.Name) ? new DirectoryInfo(folderPath).Name : meta!.Name!,
-                CoverPath = string.IsNullOrWhiteSpace(meta?.CoverPath) ? null : meta!.CoverPath,
+            playlist = new LocalPlaylistEntity {
+                Name = string.IsNullOrWhiteSpace(meta?.Name) ? new DirectoryInfo(folderPath).Name : meta.Name!,
+                CoverPath = string.IsNullOrWhiteSpace(meta?.CoverPath) ? null : meta.CoverPath,
                 Kind = PlaylistKindImportedFolder,
                 SourceRef = folderPath,
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now
             };
             playlist.Id = await InsertPlaylistAsync(connection, transaction, playlist, cancellationToken);
-        }
-        else
-        {
+        } else {
             if (!string.IsNullOrWhiteSpace(meta?.Name))
-                playlist.Name = meta!.Name!;
+                playlist.Name = meta.Name!;
             if (!string.IsNullOrWhiteSpace(meta?.CoverPath))
-                playlist.CoverPath = meta!.CoverPath;
+                playlist.CoverPath = meta.CoverPath;
         }
 
-        await ReplacePlaylistTracksFromFolderAsync(connection, transaction, playlist.Id, folderPath, meta?.SongCoverPaths, cancellationToken);
+        await ReplacePlaylistTracksFromFolderAsync(
+            connection,
+            transaction,
+            playlist.Id,
+            folderPath,
+            meta?.SongCoverPaths,
+            cancellationToken);
         playlist.UpdatedAtUtc = DateTime.UtcNow;
         await UpdatePlaylistAsync(connection, transaction, playlist, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
@@ -600,44 +694,46 @@ public sealed class LocalMusicLibraryService(
         long playlistId,
         string folderPath,
         IReadOnlyDictionary<string, string>? legacySongCovers,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await DeletePlaylistTracksAsync(connection, transaction, playlistId, cancellationToken);
 
-        var channel = Channel.CreateBounded<IReadOnlyList<LocalTrackImportData>>(new BoundedChannelOptions(4)
-        {
-            FullMode = BoundedChannelFullMode.Wait,
-            SingleReader = true,
-            SingleWriter = true
-        });
+        var channel = Channel.CreateBounded<IReadOnlyList<LocalTrackImportData>>(
+            new BoundedChannelOptions(4) {
+                FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = true
+            });
 
-        var producer = Task.Run(async () =>
-        {
-            try
-            {
-                foreach (var fileBatch in EnumerateSupportedAudioFileBatches(folderPath, LocalImportBatchSize))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var importedBatch = await PrepareLocalTrackBatchAsync(fileBatch, legacySongCovers, cancellationToken);
-                    await channel.Writer.WriteAsync(importedBatch, cancellationToken);
+        var producer = Task.Run(
+            async () => {
+                try {
+                    foreach (var fileBatch in EnumerateSupportedAudioFileBatches(folderPath, LocalImportBatchSize)) {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var importedBatch = await PrepareLocalTrackBatchAsync(
+                            fileBatch,
+                            legacySongCovers,
+                            cancellationToken);
+                        await channel.Writer.WriteAsync(importedBatch, cancellationToken);
+                    }
+
+                    channel.Writer.TryComplete();
+                } catch (Exception ex) {
+                    channel.Writer.TryComplete(ex);
+                    throw;
                 }
-
-                channel.Writer.TryComplete();
-            }
-            catch (Exception ex)
-            {
-                channel.Writer.TryComplete(ex);
-                throw;
-            }
-        }, cancellationToken);
+            },
+            cancellationToken);
 
         var position = 0;
-        await foreach (var importedBatch in channel.Reader.ReadAllAsync(cancellationToken))
-        {
-            foreach (var importedTrack in importedBatch)
-            {
+        await foreach (var importedBatch in channel.Reader.ReadAllAsync(cancellationToken)) {
+            foreach (var importedTrack in importedBatch) {
                 var track = await UpsertTrackAsync(connection, transaction, importedTrack, cancellationToken);
-                await InsertPlaylistTrackAsync(connection, transaction, playlistId, track.Id, position++, DateTime.UtcNow, cancellationToken);
+                await InsertPlaylistTrackAsync(
+                    connection,
+                    transaction,
+                    playlistId,
+                    track.Id,
+                    position++,
+                    DateTime.UtcNow,
+                    cancellationToken);
             }
         }
 
@@ -649,23 +745,13 @@ public sealed class LocalMusicLibraryService(
         SqliteTransaction transaction,
         string filePath,
         string? explicitCoverPath,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         var metadata = ReadMetadata(filePath, explicitCoverPath);
         var now = DateTime.UtcNow;
-        var lastWriteTime = System.IO.File.GetLastWriteTimeUtc(filePath);
+        var lastWriteTime = File.GetLastWriteTimeUtc(filePath);
         var fileSize = new FileInfo(filePath).Length;
-        var track = await GetTrackByLocalPathAsync(connection, transaction, filePath, cancellationToken);
-
-        if (track == null)
-        {
-            track = new LocalTrackEntity
-            {
-                SourceType = SourceTypeLocalFile,
-                LocalPath = filePath,
-                CreatedAtUtc = now
-            };
-        }
+        var track = await GetTrackByLocalPathAsync(connection, transaction, filePath, cancellationToken) ??
+                    new LocalTrackEntity { SourceType = SourceTypeLocalFile, LocalPath = filePath, CreatedAtUtc = now };
 
         track.Title = metadata.Title;
         track.Artist = metadata.Artist;
@@ -684,21 +770,14 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction transaction,
         LocalTrackImportData importedTrack,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         var metadata = importedTrack.Metadata;
         var now = DateTime.UtcNow;
-        var track = await GetTrackByLocalPathAsync(connection, transaction, importedTrack.FilePath, cancellationToken);
-
-        if (track == null)
-        {
-            track = new LocalTrackEntity
-            {
-                SourceType = SourceTypeLocalFile,
-                LocalPath = importedTrack.FilePath,
-                CreatedAtUtc = now
+        var track =
+            await GetTrackByLocalPathAsync(connection, transaction, importedTrack.FilePath, cancellationToken) ??
+            new LocalTrackEntity {
+                SourceType = SourceTypeLocalFile, LocalPath = importedTrack.FilePath, CreatedAtUtc = now
             };
-        }
 
         track.Title = metadata.Title;
         track.Artist = metadata.Artist;
@@ -718,26 +797,18 @@ public sealed class LocalMusicLibraryService(
         SqliteTransaction transaction,
         string serverFingerprint,
         JellyfinAudioItem item,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         var pseudoPath = jellyfinClient.BuildPseudoPath(serverFingerprint, item.Id);
         var now = DateTime.UtcNow;
-        var track = await GetTrackByLocalPathAsync(connection, transaction, pseudoPath, cancellationToken);
-
-        if (track == null)
-        {
-            track = new LocalTrackEntity
-            {
-                SourceType = SourceTypeJellyfin,
-                LocalPath = pseudoPath,
-                CreatedAtUtc = now
-            };
-        }
+        var track = await GetTrackByLocalPathAsync(connection, transaction, pseudoPath, cancellationToken) ??
+                    new LocalTrackEntity {
+                        SourceType = SourceTypeJellyfin, LocalPath = pseudoPath, CreatedAtUtc = now
+                    };
 
         track.SourceType = SourceTypeJellyfin;
         track.Title = string.IsNullOrWhiteSpace(item.Name) ? "未知歌曲" : item.Name;
         track.Artist = string.IsNullOrWhiteSpace(item.Artist) ? "未知艺术家" : item.Artist;
-        track.Album = item.Album ?? string.Empty;
+        track.Album = item.Album;
         track.DurationSeconds = item.DurationSeconds;
         track.CoverPath = string.IsNullOrWhiteSpace(item.CoverUrl) ? track.CoverPath : item.CoverUrl;
         track.RemoteUrl = string.IsNullOrWhiteSpace(item.StreamUrl) ? track.RemoteUrl : item.StreamUrl;
@@ -748,8 +819,7 @@ public sealed class LocalMusicLibraryService(
         return track;
     }
 
-    private static string GetJellyfinAlbumKey(JellyfinAudioItem item)
-    {
+    private static string GetJellyfinAlbumKey(JellyfinAudioItem item) {
         if (!string.IsNullOrWhiteSpace(item.AlbumId))
             return $"album:{item.AlbumId}";
 
@@ -759,8 +829,7 @@ public sealed class LocalMusicLibraryService(
         return "unknown";
     }
 
-    private static string GetJellyfinAlbumName(JellyfinAudioItem item)
-    {
+    private static string GetJellyfinAlbumName(JellyfinAudioItem item) {
         return string.IsNullOrWhiteSpace(item.Album) ? "未分专辑" : item.Album.Trim();
     }
 
@@ -768,19 +837,17 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT p.id, p.name, p.cover_path, p.updated_at, COUNT(pt.track_id) AS track_count
-            FROM playlists p
-            LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
-            WHERE p.id = $playlistId
-            GROUP BY p.id, p.name, p.cover_path, p.updated_at
-            LIMIT 1;
-            """;
+        command.CommandText = """
+                              SELECT p.id, p.name, p.cover_path, p.updated_at, COUNT(pt.track_id) AS track_count
+                              FROM playlists p
+                              LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+                              WHERE p.id = $playlistId
+                              GROUP BY p.id, p.name, p.cover_path, p.updated_at
+                              LIMIT 1;
+                              """;
         command.Parameters.AddWithValue("$playlistId", playlistId);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -792,17 +859,15 @@ public sealed class LocalMusicLibraryService(
 
     private static async Task<List<LocalPlaylistSummary>> GetPlaylistSummariesAsync(
         SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            SELECT p.id, p.name, p.cover_path, p.updated_at, COUNT(pt.track_id) AS track_count
-            FROM playlists p
-            LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
-            GROUP BY p.id, p.name, p.cover_path, p.updated_at
-            ORDER BY p.updated_at DESC, p.id DESC;
-            """;
+        command.CommandText = """
+                              SELECT p.id, p.name, p.cover_path, p.updated_at, COUNT(pt.track_id) AS track_count
+                              FROM playlists p
+                              LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+                              GROUP BY p.id, p.name, p.cover_path, p.updated_at
+                              ORDER BY p.updated_at DESC, p.id DESC;
+                              """;
 
         var playlists = new List<LocalPlaylistSummary>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -814,16 +879,14 @@ public sealed class LocalMusicLibraryService(
 
     private static async Task<List<string>> GetImportedFolderPathsAsync(
         SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            SELECT DISTINCT source_ref
-            FROM playlists
-            WHERE kind = $kind AND source_ref IS NOT NULL AND source_ref <> ''
-            ORDER BY source_ref;
-            """;
+        command.CommandText = """
+                              SELECT DISTINCT source_ref
+                              FROM playlists
+                              WHERE kind = $kind AND source_ref IS NOT NULL AND source_ref <> ''
+                              ORDER BY source_ref;
+                              """;
         command.Parameters.AddWithValue("$kind", PlaylistKindImportedFolder);
 
         var folderPaths = new List<string>();
@@ -836,28 +899,22 @@ public sealed class LocalMusicLibraryService(
 
     private static async Task<List<JellyfinLibraryRef>> GetImportedJellyfinLibrariesAsync(
         SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            SELECT DISTINCT source_ref
-            FROM playlists
-            WHERE kind = $kind AND source_ref IS NOT NULL AND source_ref <> ''
-            ORDER BY source_ref;
-            """;
+        command.CommandText = """
+                              SELECT DISTINCT source_ref
+                              FROM playlists
+                              WHERE kind = $kind AND source_ref IS NOT NULL AND source_ref <> ''
+                              ORDER BY source_ref;
+                              """;
         command.Parameters.AddWithValue("$kind", PlaylistKindJellyfinLibrary);
 
         var libraries = new HashSet<JellyfinLibraryRef>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
-        {
+        while (await reader.ReadAsync(cancellationToken)) {
             var sourceRef = reader.GetString(0);
             var parts = sourceRef.Split(':', 3);
-            if (parts.Length >= 2 &&
-                !string.IsNullOrWhiteSpace(parts[0]) &&
-                !string.IsNullOrWhiteSpace(parts[1]))
-            {
+            if (parts.Length >= 2 && !string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1])) {
                 libraries.Add(new JellyfinLibraryRef(parts[0], parts[1]));
             }
         }
@@ -871,23 +928,20 @@ public sealed class LocalMusicLibraryService(
         string kind,
         string sourceRefPrefix,
         HashSet<string> exceptSourceRefs,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT id, source_ref
-            FROM playlists
-            WHERE kind = $kind AND source_ref LIKE $sourceRefPattern;
-            """;
+        command.CommandText = """
+                              SELECT id, source_ref
+                              FROM playlists
+                              WHERE kind = $kind AND source_ref LIKE $sourceRefPattern;
+                              """;
         command.Parameters.AddWithValue("$kind", kind);
         command.Parameters.AddWithValue("$sourceRefPattern", sourceRefPrefix + "%");
 
         var playlistIds = new List<long>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
-        {
+        while (await reader.ReadAsync(cancellationToken)) {
             var sourceRef = GetNullableString(reader, "source_ref");
             if (string.IsNullOrWhiteSpace(sourceRef) || !exceptSourceRefs.Contains(sourceRef))
                 playlistIds.Add(reader.GetInt64(reader.GetOrdinal("id")));
@@ -901,17 +955,15 @@ public sealed class LocalMusicLibraryService(
         SqliteTransaction? transaction,
         string kind,
         string? sourceRef,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT id, name, cover_path, kind, source_ref, created_at, updated_at
-            FROM playlists
-            WHERE kind = $kind AND source_ref IS $sourceRef
-            LIMIT 1;
-            """;
+        command.CommandText = """
+                              SELECT id, name, cover_path, kind, source_ref, created_at, updated_at
+                              FROM playlists
+                              WHERE kind = $kind AND source_ref IS $sourceRef
+                              LIMIT 1;
+                              """;
         command.Parameters.AddWithValue("$kind", kind);
         command.Parameters.AddWithValue("$sourceRef", DbValue(sourceRef));
         return await ReadSinglePlaylistAsync(command, cancellationToken);
@@ -921,17 +973,15 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT id, name, cover_path, kind, source_ref, created_at, updated_at
-            FROM playlists
-            WHERE id = $playlistId
-            LIMIT 1;
-            """;
+        command.CommandText = """
+                              SELECT id, name, cover_path, kind, source_ref, created_at, updated_at
+                              FROM playlists
+                              WHERE id = $playlistId
+                              LIMIT 1;
+                              """;
         command.Parameters.AddWithValue("$playlistId", playlistId);
         return await ReadSinglePlaylistAsync(command, cancellationToken);
     }
@@ -940,18 +990,16 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long trackId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT id, source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
-                   file_size, last_write_time_utc, created_at, updated_at
-            FROM tracks
-            WHERE id = $trackId
-            LIMIT 1;
-            """;
+        command.CommandText = """
+                              SELECT id, source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
+                                     file_size, last_write_time_utc, created_at, updated_at
+                              FROM tracks
+                              WHERE id = $trackId
+                              LIMIT 1;
+                              """;
         command.Parameters.AddWithValue("$trackId", trackId);
         return await ReadSingleTrackAsync(command, cancellationToken);
     }
@@ -960,18 +1008,16 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         string localPath,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            SELECT id, source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
-                   file_size, last_write_time_utc, created_at, updated_at
-            FROM tracks
-            WHERE local_path = $localPath
-            LIMIT 1;
-            """;
+        command.CommandText = """
+                              SELECT id, source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
+                                     file_size, last_write_time_utc, created_at, updated_at
+                              FROM tracks
+                              WHERE local_path = $localPath
+                              LIMIT 1;
+                              """;
         command.Parameters.AddWithValue("$localPath", localPath);
         return await ReadSingleTrackAsync(command, cancellationToken);
     }
@@ -980,15 +1026,13 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         LocalPlaylistEntity playlist,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            INSERT INTO playlists (name, cover_path, kind, source_ref, created_at, updated_at)
-            VALUES ($name, $coverPath, $kind, $sourceRef, $createdAt, $updatedAt);
-            """;
+        command.CommandText = """
+                              INSERT INTO playlists (name, cover_path, kind, source_ref, created_at, updated_at)
+                              VALUES ($name, $coverPath, $kind, $sourceRef, $createdAt, $updatedAt);
+                              """;
         AddPlaylistParameters(command, playlist);
         await command.ExecuteNonQueryAsync(cancellationToken);
         var id = await GetLastInsertRowIdAsync(connection, transaction, cancellationToken);
@@ -1000,21 +1044,19 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         LocalPlaylistEntity playlist,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            UPDATE playlists
-            SET name = $name,
-                cover_path = $coverPath,
-                kind = $kind,
-                source_ref = $sourceRef,
-                created_at = $createdAt,
-                updated_at = $updatedAt
-            WHERE id = $id;
-            """;
+        command.CommandText = """
+                              UPDATE playlists
+                              SET name = $name,
+                                  cover_path = $coverPath,
+                                  kind = $kind,
+                                  source_ref = $sourceRef,
+                                  created_at = $createdAt,
+                                  updated_at = $updatedAt
+                              WHERE id = $id;
+                              """;
         command.Parameters.AddWithValue("$id", playlist.Id);
         AddPlaylistParameters(command, playlist);
         await command.ExecuteNonQueryAsync(cancellationToken);
@@ -1024,8 +1066,7 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "DELETE FROM playlists WHERE id = $playlistId;";
@@ -1037,8 +1078,7 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "DELETE FROM playlist_tracks WHERE playlist_id = $playlistId;";
@@ -1051,15 +1091,13 @@ public sealed class LocalMusicLibraryService(
         SqliteTransaction? transaction,
         long playlistId,
         long trackId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            DELETE FROM playlist_tracks
-            WHERE playlist_id = $playlistId AND track_id = $trackId;
-            """;
+        command.CommandText = """
+                              DELETE FROM playlist_tracks
+                              WHERE playlist_id = $playlistId AND track_id = $trackId;
+                              """;
         command.Parameters.AddWithValue("$playlistId", playlistId);
         command.Parameters.AddWithValue("$trackId", trackId);
         return await command.ExecuteNonQueryAsync(cancellationToken);
@@ -1069,8 +1107,7 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "SELECT track_id FROM playlist_tracks WHERE playlist_id = $playlistId;";
@@ -1088,11 +1125,11 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         long playlistId,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = "SELECT COALESCE(MAX(position) + 1, 0) FROM playlist_tracks WHERE playlist_id = $playlistId;";
+        command.CommandText =
+            "SELECT COALESCE(MAX(position) + 1, 0) FROM playlist_tracks WHERE playlist_id = $playlistId;";
         command.Parameters.AddWithValue("$playlistId", playlistId);
         return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken) ?? 0);
     }
@@ -1104,15 +1141,13 @@ public sealed class LocalMusicLibraryService(
         long trackId,
         int position,
         DateTime addedAt,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position, added_at)
-            VALUES ($playlistId, $trackId, $position, $addedAt);
-            """;
+        command.CommandText = """
+                              INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position, added_at)
+                              VALUES ($playlistId, $trackId, $position, $addedAt);
+                              """;
         command.Parameters.AddWithValue("$playlistId", playlistId);
         command.Parameters.AddWithValue("$trackId", trackId);
         command.Parameters.AddWithValue("$position", position);
@@ -1124,32 +1159,30 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         LocalTrackEntity track,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            INSERT INTO tracks (
-                source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
-                file_size, last_write_time_utc, created_at, updated_at
-            )
-            VALUES (
-                $sourceType, $localPath, $title, $artist, $album, $durationSeconds, $coverPath, $remoteUrl,
-                $fileSize, $lastWriteTimeUtc, $createdAt, $updatedAt
-            )
-            ON CONFLICT(local_path) DO UPDATE SET
-                source_type = excluded.source_type,
-                title = excluded.title,
-                artist = excluded.artist,
-                album = excluded.album,
-                duration_seconds = excluded.duration_seconds,
-                cover_path = excluded.cover_path,
-                remote_url = excluded.remote_url,
-                file_size = excluded.file_size,
-                last_write_time_utc = excluded.last_write_time_utc,
-                updated_at = excluded.updated_at;
-            """;
+        command.CommandText = """
+                              INSERT INTO tracks (
+                                  source_type, local_path, title, artist, album, duration_seconds, cover_path, remote_url,
+                                  file_size, last_write_time_utc, created_at, updated_at
+                              )
+                              VALUES (
+                                  $sourceType, $localPath, $title, $artist, $album, $durationSeconds, $coverPath, $remoteUrl,
+                                  $fileSize, $lastWriteTimeUtc, $createdAt, $updatedAt
+                              )
+                              ON CONFLICT(local_path) DO UPDATE SET
+                                  source_type = excluded.source_type,
+                                  title = excluded.title,
+                                  artist = excluded.artist,
+                                  album = excluded.album,
+                                  duration_seconds = excluded.duration_seconds,
+                                  cover_path = excluded.cover_path,
+                                  remote_url = excluded.remote_url,
+                                  file_size = excluded.file_size,
+                                  last_write_time_utc = excluded.last_write_time_utc,
+                                  updated_at = excluded.updated_at;
+                              """;
         AddTrackParameters(command, track);
         await command.ExecuteNonQueryAsync(cancellationToken);
 
@@ -1161,27 +1194,25 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         LocalTrackEntity track,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText =
-            """
-            UPDATE tracks
-            SET source_type = $sourceType,
-                local_path = $localPath,
-                title = $title,
-                artist = $artist,
-                album = $album,
-                duration_seconds = $durationSeconds,
-                cover_path = $coverPath,
-                remote_url = $remoteUrl,
-                file_size = $fileSize,
-                last_write_time_utc = $lastWriteTimeUtc,
-                created_at = $createdAt,
-                updated_at = $updatedAt
-            WHERE id = $id;
-            """;
+        command.CommandText = """
+                              UPDATE tracks
+                              SET source_type = $sourceType,
+                                  local_path = $localPath,
+                                  title = $title,
+                                  artist = $artist,
+                                  album = $album,
+                                  duration_seconds = $durationSeconds,
+                                  cover_path = $coverPath,
+                                  remote_url = $remoteUrl,
+                                  file_size = $fileSize,
+                                  last_write_time_utc = $lastWriteTimeUtc,
+                                  created_at = $createdAt,
+                                  updated_at = $updatedAt
+                              WHERE id = $id;
+                              """;
         command.Parameters.AddWithValue("$id", track.Id);
         AddTrackParameters(command, track);
         await command.ExecuteNonQueryAsync(cancellationToken);
@@ -1191,8 +1222,7 @@ public sealed class LocalMusicLibraryService(
         SqliteConnection connection,
         SqliteTransaction? transaction,
         string localPath,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "SELECT id FROM tracks WHERE local_path = $localPath LIMIT 1;";
@@ -1203,8 +1233,7 @@ public sealed class LocalMusicLibraryService(
     private static async Task<long> GetLastInsertRowIdAsync(
         SqliteConnection connection,
         SqliteTransaction? transaction,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "SELECT last_insert_rowid();";
@@ -1213,22 +1242,19 @@ public sealed class LocalMusicLibraryService(
 
     private static async Task<LocalPlaylistEntity?> ReadSinglePlaylistAsync(
         SqliteCommand command,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadPlaylist(reader) : null;
     }
 
     private static async Task<LocalTrackEntity?> ReadSingleTrackAsync(
         SqliteCommand command,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadTrack(reader) : null;
     }
 
-    private static LocalPlaylistSummary ReadPlaylistSummary(SqliteDataReader reader)
-    {
+    private static LocalPlaylistSummary ReadPlaylistSummary(SqliteDataReader reader) {
         return new LocalPlaylistSummary(
             reader.GetInt64(reader.GetOrdinal("id")),
             reader.GetString(reader.GetOrdinal("name")),
@@ -1237,8 +1263,7 @@ public sealed class LocalMusicLibraryService(
             AppDatabase.ReadDateTime(reader, "updated_at"));
     }
 
-    private static LocalTrackItem ReadTrackItem(SqliteDataReader reader)
-    {
+    private static LocalTrackItem ReadTrackItem(SqliteDataReader reader) {
         return new LocalTrackItem(
             reader.GetInt64(reader.GetOrdinal("id")),
             reader.GetString(reader.GetOrdinal("title")),
@@ -1251,10 +1276,8 @@ public sealed class LocalMusicLibraryService(
             GetNullableString(reader, "remote_url"));
     }
 
-    private static LocalPlaylistEntity ReadPlaylist(SqliteDataReader reader)
-    {
-        return new LocalPlaylistEntity
-        {
+    private static LocalPlaylistEntity ReadPlaylist(SqliteDataReader reader) {
+        return new LocalPlaylistEntity {
             Id = reader.GetInt64(reader.GetOrdinal("id")),
             Name = reader.GetString(reader.GetOrdinal("name")),
             CoverPath = GetNullableString(reader, "cover_path"),
@@ -1265,10 +1288,8 @@ public sealed class LocalMusicLibraryService(
         };
     }
 
-    private static LocalTrackEntity ReadTrack(SqliteDataReader reader)
-    {
-        return new LocalTrackEntity
-        {
+    private static LocalTrackEntity ReadTrack(SqliteDataReader reader) {
+        return new LocalTrackEntity {
             Id = reader.GetInt64(reader.GetOrdinal("id")),
             SourceType = reader.GetString(reader.GetOrdinal("source_type")),
             LocalPath = reader.GetString(reader.GetOrdinal("local_path")),
@@ -1285,8 +1306,7 @@ public sealed class LocalMusicLibraryService(
         };
     }
 
-    private static void AddPlaylistParameters(SqliteCommand command, LocalPlaylistEntity playlist)
-    {
+    private static void AddPlaylistParameters(SqliteCommand command, LocalPlaylistEntity playlist) {
         command.Parameters.AddWithValue("$name", playlist.Name);
         command.Parameters.AddWithValue("$coverPath", DbValue(playlist.CoverPath));
         command.Parameters.AddWithValue("$kind", playlist.Kind);
@@ -1295,8 +1315,7 @@ public sealed class LocalMusicLibraryService(
         command.Parameters.AddWithValue("$updatedAt", AppDatabase.FormatDateTime(playlist.UpdatedAtUtc));
     }
 
-    private static void AddTrackParameters(SqliteCommand command, LocalTrackEntity track)
-    {
+    private static void AddTrackParameters(SqliteCommand command, LocalTrackEntity track) {
         command.Parameters.AddWithValue("$sourceType", track.SourceType);
         command.Parameters.AddWithValue("$localPath", track.LocalPath);
         command.Parameters.AddWithValue("$title", track.Title);
@@ -1311,27 +1330,20 @@ public sealed class LocalMusicLibraryService(
         command.Parameters.AddWithValue("$updatedAt", AppDatabase.FormatDateTime(track.UpdatedAtUtc));
     }
 
-    private static string? GetNullableString(SqliteDataReader reader, string name)
-    {
+    private static string? GetNullableString(SqliteDataReader reader, string name) {
         var ordinal = reader.GetOrdinal(name);
         return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
     }
 
-    private static object DbValue(string? value)
-    {
-        return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value;
+    private static object DbValue(string? value) { return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value; }
+
+    private static string EscapeLikePattern(string value) {
+        return value.Replace(@"\", @"\\", StringComparison.Ordinal)
+                    .Replace("%", @"\%", StringComparison.Ordinal)
+                    .Replace("_", @"\_", StringComparison.Ordinal);
     }
 
-    private static string EscapeLikePattern(string value)
-    {
-        return value
-            .Replace(@"\", @"\\", StringComparison.Ordinal)
-            .Replace("%", @"\%", StringComparison.Ordinal)
-            .Replace("_", @"\_", StringComparison.Ordinal);
-    }
-
-    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
-    {
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken) {
         if (_initialized)
             return;
 
@@ -1341,11 +1353,13 @@ public sealed class LocalMusicLibraryService(
     private async Task<IReadOnlyList<LocalTrackImportData>> PrepareLocalTrackBatchAsync(
         IReadOnlyList<string> filePaths,
         IReadOnlyDictionary<string, string>? legacySongCovers,
-        CancellationToken cancellationToken)
-    {
+        CancellationToken cancellationToken) {
         var tasks = new Task<LocalTrackImportData>[filePaths.Count];
         for (var i = 0; i < filePaths.Count; i++)
-            tasks[i] = ReadTrackImportDataAsync(filePaths[i], GetLegacyCover(filePaths[i], legacySongCovers), cancellationToken);
+            tasks[i] = ReadTrackImportDataAsync(
+                filePaths[i],
+                GetLegacyCover(filePaths[i], legacySongCovers),
+                cancellationToken);
 
         return await Task.WhenAll(tasks);
     }
@@ -1353,22 +1367,22 @@ public sealed class LocalMusicLibraryService(
     private async Task<LocalTrackImportData> ReadTrackImportDataAsync(
         string filePath,
         string? explicitCoverPath,
-        CancellationToken cancellationToken)
-    {
-        return await Task.Run(() =>
-        {
-            var metadata = ReadMetadata(filePath, explicitCoverPath);
-            var lastWriteTime = System.IO.File.GetLastWriteTimeUtc(filePath);
-            var fileSize = new FileInfo(filePath).Length;
-            return new LocalTrackImportData(filePath, fileSize, lastWriteTime, metadata);
-        }, cancellationToken);
+        CancellationToken cancellationToken) {
+        return await Task.Run(
+            () => {
+                var metadata = ReadMetadata(filePath, explicitCoverPath);
+                var lastWriteTime = File.GetLastWriteTimeUtc(filePath);
+                var fileSize = new FileInfo(filePath).Length;
+                return new LocalTrackImportData(filePath, fileSize, lastWriteTime, metadata);
+            },
+            cancellationToken);
     }
 
-    private static IEnumerable<IReadOnlyList<string>> EnumerateSupportedAudioFileBatches(string folderPath, int batchSize)
-    {
+    private static IEnumerable<IReadOnlyList<string>> EnumerateSupportedAudioFileBatches(
+        string folderPath,
+        int batchSize) {
         var batch = new List<string>(batchSize);
-        foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.*", SearchOption.AllDirectories))
-        {
+        foreach (var filePath in Directory.EnumerateFiles(folderPath, "*.*", SearchOption.AllDirectories)) {
             if (!IsSupportedAudioFile(filePath))
                 continue;
 
@@ -1384,91 +1398,85 @@ public sealed class LocalMusicLibraryService(
             yield return batch;
     }
 
-    private LocalTrackMetadata ReadMetadata(string filePath, string? explicitCoverPath)
-    {
+    private LocalTrackMetadata ReadMetadata(string filePath, string? explicitCoverPath) {
         var title = Path.GetFileNameWithoutExtension(filePath);
         var artist = "未知艺术家";
         var album = "";
         double duration = 0;
         var coverPath = IsUsableFile(explicitCoverPath) ? explicitCoverPath : null;
 
-        try
-        {
+        try {
             var track = new Track(filePath);
             title = string.IsNullOrWhiteSpace(track.Title) ? title : track.Title;
             artist = NormalizeAtlArtists(track.Artist, artist);
             album = track.Album ?? "";
             duration = track.DurationMs > 0 ? track.DurationMs / 1000d : track.Duration;
             coverPath ??= GetEmbeddedSongCoverSource(filePath, track);
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
             logger.LogWarning(ex, "读取标签失败，已降级为文件名加载。 file={File}", filePath);
         }
 
         return new LocalTrackMetadata(title, artist, album, duration, coverPath);
     }
 
-    private static string? GetLegacyCover(string filePath, IReadOnlyDictionary<string, string>? legacySongCovers)
-    {
+    private static string? GetLegacyCover(string filePath, IReadOnlyDictionary<string, string>? legacySongCovers) {
         if (legacySongCovers == null)
             return null;
 
-        return legacySongCovers.TryGetValue(Path.GetFileName(filePath), out var coverPath) && IsUsableFile(coverPath)
-            ? coverPath
-            : null;
+        return legacySongCovers.TryGetValue(Path.GetFileName(filePath), out var coverPath) && IsUsableFile(coverPath) ?
+            coverPath :
+            null;
     }
 
-    private static bool IsSupportedAudioFile(string filePath)
-    {
-        return System.IO.File.Exists(filePath) && SupportedLocalAudioExtensions.Contains(Path.GetExtension(filePath));
+    private static bool IsSupportedAudioFile(string filePath) {
+        return File.Exists(filePath) && _supportedLocalAudioExtensions.Contains(Path.GetExtension(filePath));
     }
 
-    private static bool IsUsableFile(string? filePath)
-    {
-        return !string.IsNullOrWhiteSpace(filePath) && System.IO.File.Exists(filePath);
+    private static bool IsUsableFile(string? filePath) {
+        return !string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath);
     }
 
-    private static string NormalizeAtlArtists(string? artistValue, string fallbackArtist)
-    {
+    private static string NormalizeAtlArtists(string? artistValue, string fallbackArtist) {
         if (string.IsNullOrWhiteSpace(artistValue))
             return fallbackArtist;
 
-        var artists = artistValue
-            .Split(Settings.DisplayValueSeparator, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var artists = artistValue.Split(
+            Settings.DisplayValueSeparator,
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         return artists.Length > 0 ? string.Join(", ", artists) : fallbackArtist;
     }
 
-    private static string? GetEmbeddedSongCoverSource(string songPath, Track track)
-    {
-        var picture = track.EmbeddedPictures?
-                          .AsValueEnumerable().FirstOrDefault(x => x.PicType == PictureInfo.PIC_TYPE.Front && x.PictureData.Length > 0)
-            ?? track.EmbeddedPictures?.AsValueEnumerable().FirstOrDefault(x => x.PictureData.Length > 0);
+    private static string? GetEmbeddedSongCoverSource(string songPath, Track track) {
+        var picture =
+            track.EmbeddedPictures?.AsValueEnumerable()
+                 .FirstOrDefault(x => x.PicType == PictureInfo.PIC_TYPE.Front && x.PictureData.Length > 0) ??
+            track.EmbeddedPictures?.AsValueEnumerable().FirstOrDefault(x => x.PictureData.Length > 0);
 
         return picture == null ? null : LocalImageSourceHelper.BuildEmbeddedCoverSource(songPath);
     }
 
-    private static async Task WriteEmbeddedCoverAsync(string audioFilePath, string imagePath, CancellationToken cancellationToken)
-    {
-        var imageBytes = await System.IO.File.ReadAllBytesAsync(imagePath, cancellationToken);
-        await Task.Run(() =>
-        {
-            var track = new Track(audioFilePath);
-            var pictures = track.EmbeddedPictures;
-            for (var i = pictures.Count - 1; i >= 0; i--)
-            {
-                if (pictures[i].PicType == PictureInfo.PIC_TYPE.Front)
-                    pictures.RemoveAt(i);
-            }
+    private static async Task WriteEmbeddedCoverAsync(
+        string audioFilePath,
+        string imagePath,
+        CancellationToken cancellationToken) {
+        var imageBytes = await File.ReadAllBytesAsync(imagePath, cancellationToken);
+        await Task.Run(
+            () => {
+                var track = new Track(audioFilePath);
+                var pictures = track.EmbeddedPictures;
+                for (var i = pictures.Count - 1; i >= 0; i--) {
+                    if (pictures[i].PicType == PictureInfo.PIC_TYPE.Front)
+                        pictures.RemoveAt(i);
+                }
 
-            pictures.Insert(0, PictureInfo.fromBinaryData(imageBytes, PictureInfo.PIC_TYPE.Front));
-            if (!track.Save())
-                throw new IOException($"写入嵌入封面失败: {audioFilePath}");
-        }, cancellationToken);
+                pictures.Insert(0, PictureInfo.fromBinaryData(imageBytes, PictureInfo.PIC_TYPE.Front));
+                if (!track.Save())
+                    throw new IOException($"写入嵌入封面失败: {audioFilePath}");
+            },
+            cancellationToken);
     }
 
-    private static string GetStableHash(string value)
-    {
+    private static string GetStableHash(string value) {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
         return Convert.ToHexString(bytes).ToLowerInvariant();
     }
@@ -1486,12 +1494,7 @@ public sealed class LocalMusicLibraryService(
         DateTime LastWriteTimeUtc,
         LocalTrackMetadata Metadata);
 
-    private sealed record JellyfinAlbumGroup(
-        string Key,
-        string Name,
-        List<JellyfinAudioItem> Items);
+    private sealed record JellyfinAlbumGroup(string Key, string Name, List<JellyfinAudioItem> Items);
 
-    private sealed record JellyfinLibraryRef(
-        string ServerFingerprint,
-        string LibraryId);
+    private sealed record JellyfinLibraryRef(string ServerFingerprint, string LibraryId);
 }

--- a/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicSearchDialogService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/LocalMusicSearchDialogService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using KugouAvaloniaPlayer.Controls;
+using KugouAvaloniaPlayer.ViewModels;
+using SukiUI.Dialogs;
+
+namespace KugouAvaloniaPlayer.Services;
+
+public interface ILocalMusicSearchDialogService
+{
+    void Show(Func<LocalTrackSearchResult, Task> openResultAction);
+}
+
+public sealed class LocalMusicSearchDialogService(
+    ISukiDialogManager dialogManager,
+    ILocalMusicLibraryService localMusicLibraryService,
+    IUiDispatcherService uiDispatcher) : ILocalMusicSearchDialogService
+{
+    public void Show(Func<LocalTrackSearchResult, Task> openResultAction)
+    {
+        uiDispatcher.RunOrPost(() =>
+        {
+            LocalMusicSearchDialogViewModel? viewModel = null;
+
+            void Dismiss()
+            {
+                viewModel?.Dispose();
+                dialogManager.DismissDialog();
+            }
+
+            viewModel = new LocalMusicSearchDialogViewModel(
+                localMusicLibraryService,
+                async result =>
+                {
+                    Dismiss();
+                    await openResultAction(result);
+                },
+                Dismiss);
+
+            dialogManager.CreateDialog()
+                .WithContent(new LocalMusicSearchDialog
+                {
+                    DataContext = viewModel
+                })
+                .TryShow();
+        });
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/Services/TrackPlaylistSearchDialogService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/TrackPlaylistSearchDialogService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using KugouAvaloniaPlayer.Controls;
+using KugouAvaloniaPlayer.ViewModels;
+using SukiUI.Dialogs;
+
+namespace KugouAvaloniaPlayer.Services;
+
+public interface ITrackPlaylistSearchDialogService
+{
+    void Show(SongItem song, Func<LocalTrackSearchResult, Task> openResultAction);
+}
+
+public sealed class TrackPlaylistSearchDialogService(
+    ISukiDialogManager dialogManager,
+    ILocalMusicLibraryService localMusicLibraryService,
+    IUiDispatcherService uiDispatcher) : ITrackPlaylistSearchDialogService
+{
+    public void Show(SongItem song, Func<LocalTrackSearchResult, Task> openResultAction)
+    {
+        uiDispatcher.RunOrPost(() =>
+        {
+            TrackPlaylistSearchDialogViewModel? viewModel = null;
+
+            TrackPlaylistSearchDialogViewModel? model = viewModel;
+
+            viewModel = new TrackPlaylistSearchDialogViewModel(
+                localMusicLibraryService,
+                song,
+                async result =>
+                {
+                    Dismiss();
+                    await openResultAction(result);
+                },
+                Dismiss);
+
+            dialogManager.CreateDialog()
+                .WithContent(new TrackPlaylistSearchDialog
+                {
+                    DataContext = viewModel
+                })
+                .TryShow();
+            return;
+
+            void Dismiss()
+            {
+                model?.Dispose();
+                dialogManager.DismissDialog();
+            }
+        });
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
@@ -29,6 +29,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     private readonly IFolderPickerService _folderPickerService;
     private readonly IJellyfinClient _jellyfinClient;
     private readonly ILocalMusicLibraryService _localMusicLibraryService;
+    private readonly ILocalMusicSearchDialogService _localMusicSearchDialogService;
     private readonly ILogger<LocalMusicLibraryViewModel> _logger;
     private readonly ISukiToastManager _toastManager;
     private readonly List<SongItem> _selectedPlaylistSongsDefaultOrder = new();
@@ -54,11 +55,17 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     [NotifyPropertyChangedFor(nameof(IsLocalLibraryHome))]
     public partial PlaylistItem? SelectedPlaylist { get; set; }
 
+    [ObservableProperty]
+    public partial SongLocateRequest? PendingSongLocateRequest { get; set; }
+
+    private long _songLocateSequence;
+
     public LocalMusicLibraryViewModel(
         ICreatePlaylistDialogService createPlaylistDialogService,
         IFolderPickerService folderPickerService,
         IJellyfinClient jellyfinClient,
         ILocalMusicLibraryService localMusicLibraryService,
+        ILocalMusicSearchDialogService localMusicSearchDialogService,
         ISukiToastManager toastManager,
         ILogger<LocalMusicLibraryViewModel> logger)
     {
@@ -66,6 +73,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         _folderPickerService = folderPickerService;
         _jellyfinClient = jellyfinClient;
         _localMusicLibraryService = localMusicLibraryService;
+        _localMusicSearchDialogService = localMusicSearchDialogService;
         _toastManager = toastManager;
         _logger = logger;
         CurrentSortText = GetSortText(SettingsManager.Settings.LocalPlaylistSongSortMode);
@@ -109,6 +117,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     {
         IsShowingSongs = false;
         SelectedPlaylist = null;
+        PendingSongLocateRequest = null;
         _selectedPlaylistSongsDefaultOrder.Clear();
         SelectedPlaylistSongs.Clear();
         OnPropertyChanged(nameof(IsLocalLibraryHome));
@@ -118,6 +127,68 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     private void BackFromPlaylist()
     {
         GoBack();
+    }
+
+    [RelayCommand]
+    private void ShowLocalMusicSearchDialog()
+    {
+        _localMusicSearchDialogService.Show(OpenSearchResultAsync);
+    }
+
+    private async Task OpenSearchResultAsync(LocalTrackSearchResult result)
+    {
+        try
+        {
+            var playlistId = result.PlaylistId.ToString();
+            var playlist = LocalLibraryPlaylists
+                .AsValueEnumerable()
+                .FirstOrDefault(item => item.Id == playlistId);
+
+            if (playlist is null)
+            {
+                await LoadLocalLibraryAsync();
+                playlist = LocalLibraryPlaylists
+                    .AsValueEnumerable()
+                    .FirstOrDefault(item => item.Id == playlistId);
+            }
+
+            if (playlist is null)
+            {
+                ShowSearchNavigationError("对应歌单已不存在，请重新搜索。");
+                return;
+            }
+
+            await OpenPlaylist(playlist);
+            if (!SelectedPlaylistSongs.AsValueEnumerable().Any(song => song.LocalTrackId == result.Track.Id))
+            {
+                ShowSearchNavigationError("歌曲已不在对应歌单中，请重新搜索。");
+                return;
+            }
+
+            PendingSongLocateRequest = new SongLocateRequest(
+                result.Track.Id,
+                ++_songLocateSequence);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "打开本地搜索结果失败 playlistId={PlaylistId}, trackId={TrackId}",
+                result.PlaylistId,
+                result.Track.Id);
+            ShowSearchNavigationError(ex.Message);
+        }
+    }
+
+    private void ShowSearchNavigationError(string message)
+    {
+        _toastManager.CreateToast()
+            .OfType(NotificationType.Warning)
+            .WithTitle("无法打开搜索结果")
+            .WithContent(message)
+            .Dismiss().After(TimeSpan.FromSeconds(4))
+            .Dismiss().ByClicking()
+            .Queue();
     }
 
     [RelayCommand]
@@ -149,6 +220,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         if (item.Type != PlaylistType.Local)
             return;
 
+        PendingSongLocateRequest = null;
         SelectedPlaylist = item;
         IsShowingSongs = true;
         _selectedPlaylistSongsDefaultOrder.Clear();

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
@@ -30,6 +30,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     private readonly IJellyfinClient _jellyfinClient;
     private readonly ILocalMusicLibraryService _localMusicLibraryService;
     private readonly ILocalMusicSearchDialogService _localMusicSearchDialogService;
+    private readonly ITrackPlaylistSearchDialogService _trackPlaylistSearchDialogService;
     private readonly ILogger<LocalMusicLibraryViewModel> _logger;
     private readonly ISukiToastManager _toastManager;
     private readonly List<SongItem> _selectedPlaylistSongsDefaultOrder = new();
@@ -66,6 +67,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         IJellyfinClient jellyfinClient,
         ILocalMusicLibraryService localMusicLibraryService,
         ILocalMusicSearchDialogService localMusicSearchDialogService,
+        ITrackPlaylistSearchDialogService trackPlaylistSearchDialogService,
         ISukiToastManager toastManager,
         ILogger<LocalMusicLibraryViewModel> logger)
     {
@@ -74,6 +76,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         _jellyfinClient = jellyfinClient;
         _localMusicLibraryService = localMusicLibraryService;
         _localMusicSearchDialogService = localMusicSearchDialogService;
+        _trackPlaylistSearchDialogService = trackPlaylistSearchDialogService;
         _toastManager = toastManager;
         _logger = logger;
         CurrentSortText = GetSortText(SettingsManager.Settings.LocalPlaylistSongSortMode);
@@ -86,6 +89,8 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             (_, m) => _ = RemoveSongFromPlaylistSafelyAsync(m.Song));
         WeakReferenceMessenger.Default.Register<RefreshPlaylistsMessage>(this,
             (_, _) => _ = LoadLocalLibraryAsync());
+        WeakReferenceMessenger.Default.Register<ShowTrackPlaylistSearchDialogMessage>(this,
+            (_, m) => ShowTrackPlaylistSearchDialog(m.Song));
     }
 
     public bool IsLocalPlaylist => SelectedPlaylist?.Type == PlaylistType.Local;
@@ -133,6 +138,14 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
     private void ShowLocalMusicSearchDialog()
     {
         _localMusicSearchDialogService.Show(OpenSearchResultAsync);
+    }
+
+    private void ShowTrackPlaylistSearchDialog(SongItem song)
+    {
+        if (song.LocalTrackId <= 0)
+            return;
+
+        _trackPlaylistSearchDialogService.Show(song, OpenSearchResultAsync);
     }
 
     private async Task OpenSearchResultAsync(LocalTrackSearchResult result)

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicSearchDialogViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicSearchDialogViewModel.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using KugouAvaloniaPlayer.Converters;
+using KugouAvaloniaPlayer.Services;
+
+namespace KugouAvaloniaPlayer.ViewModels;
+
+public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDisposable
+{
+    private readonly Func<LocalTrackSearchResult, Task> _openResultAction;
+    private readonly Action _cancelAction;
+    private readonly ILocalMusicLibraryService _localMusicLibraryService;
+    private CancellationTokenSource? _searchCancellation;
+    private long _searchVersion;
+
+    [ObservableProperty]
+    public partial string? SearchText { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowPromptState))]
+    [NotifyPropertyChangedFor(nameof(ShowEmptyState))]
+    public partial bool HasSearched { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowPromptState))]
+    [NotifyPropertyChangedFor(nameof(ShowEmptyState))]
+    public partial bool IsSearching { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasError))]
+    [NotifyPropertyChangedFor(nameof(ShowEmptyState))]
+    public partial string? ErrorMessage { get; set; }
+
+    public LocalMusicSearchDialogViewModel(
+        ILocalMusicLibraryService localMusicLibraryService,
+        Func<LocalTrackSearchResult, Task> openResultAction,
+        Action cancelAction)
+    {
+        _localMusicLibraryService = localMusicLibraryService;
+        _openResultAction = openResultAction;
+        _cancelAction = cancelAction;
+    }
+
+    public ObservableCollection<LocalMusicSearchResultItemViewModel> Results { get; } = new();
+
+    public bool HasResults => Results.Count > 0;
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+    public bool ShowPromptState => !HasSearched && !IsSearching;
+    public bool ShowEmptyState => HasSearched && !IsSearching && !HasResults && !HasError;
+
+    [RelayCommand]
+    private async Task SearchAsync()
+    {
+        var keyword = SearchText?.Trim();
+        var searchVersion = Interlocked.Increment(ref _searchVersion);
+
+        _searchCancellation?.Cancel();
+        _searchCancellation?.Dispose();
+        _searchCancellation = null;
+
+        Results.Clear();
+        NotifyResultStateChanged();
+        ErrorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            HasSearched = false;
+            IsSearching = false;
+            return;
+        }
+
+        var cancellation = new CancellationTokenSource();
+        _searchCancellation = cancellation;
+        HasSearched = true;
+        IsSearching = true;
+
+        try
+        {
+            var results = await _localMusicLibraryService.SearchTracksAsync(keyword, cancellation.Token);
+            if (searchVersion != _searchVersion || cancellation.IsCancellationRequested)
+                return;
+
+            foreach (var result in results)
+                Results.Add(new LocalMusicSearchResultItemViewModel(result));
+
+            NotifyResultStateChanged();
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (searchVersion == _searchVersion)
+                ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            if (searchVersion == _searchVersion)
+            {
+                IsSearching = false;
+                NotifyResultStateChanged();
+            }
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenResultAsync(LocalMusicSearchResultItemViewModel? item)
+    {
+        if (item is null || IsSearching)
+            return;
+
+        CancelPendingSearch();
+        await _openResultAction(item.Result);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        CancelPendingSearch();
+        _cancelAction();
+    }
+
+    public void Dispose()
+    {
+        CancelPendingSearch();
+        GC.SuppressFinalize(this);
+    }
+
+    private void CancelPendingSearch()
+    {
+        Interlocked.Increment(ref _searchVersion);
+        _searchCancellation?.Cancel();
+        _searchCancellation?.Dispose();
+        _searchCancellation = null;
+    }
+
+    private void NotifyResultStateChanged()
+    {
+        OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(ShowEmptyState));
+    }
+}
+
+public sealed class LocalMusicSearchResultItemViewModel
+{
+    public LocalMusicSearchResultItemViewModel(LocalTrackSearchResult result)
+    {
+        Result = result;
+        Cover = ResolveCover(result.Track);
+    }
+
+    public LocalTrackSearchResult Result { get; }
+    public string Title => Result.Track.Title;
+    public string Artist => Result.Track.Artist;
+    public string Album => string.IsNullOrWhiteSpace(Result.Track.Album) ? "未知专辑" : Result.Track.Album;
+    public string PlaylistName => Result.PlaylistName;
+    public double DurationSeconds => Result.Track.DurationSeconds;
+    public string Cover { get; }
+
+    private static string ResolveCover(LocalTrackItem track)
+    {
+        const string defaultSongCover = "avares://KugouAvaloniaPlayer/Assets/default_song.png";
+
+        if (string.Equals(track.SourceType, LocalMusicLibraryService.SourceTypeJellyfin, StringComparison.Ordinal))
+            return string.IsNullOrWhiteSpace(track.CoverPath) ? defaultSongCover : track.CoverPath;
+
+        if (!string.IsNullOrWhiteSpace(track.CoverPath))
+        {
+            if (LocalImageSourceHelper.TryGetEmbeddedCoverFilePath(track.CoverPath, out _))
+                return track.CoverPath;
+
+            if (File.Exists(track.CoverPath))
+                return new Uri(track.CoverPath).AbsoluteUri;
+        }
+
+        return string.IsNullOrWhiteSpace(track.LocalPath) || !File.Exists(track.LocalPath)
+            ? defaultSongCover
+            : LocalImageSourceHelper.BuildEmbeddedCoverSource(track.LocalPath);
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicSearchDialogViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicSearchDialogViewModel.cs
@@ -12,9 +12,9 @@ namespace KugouAvaloniaPlayer.ViewModels;
 
 public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDisposable
 {
+    private readonly ILocalMusicLibraryService _localMusicLibraryService;
     private readonly Func<LocalTrackSearchResult, Task> _openResultAction;
     private readonly Action _cancelAction;
-    private readonly ILocalMusicLibraryService _localMusicLibraryService;
     private CancellationTokenSource? _searchCancellation;
     private long _searchVersion;
 
@@ -46,7 +46,7 @@ public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDispos
         _cancelAction = cancelAction;
     }
 
-    public ObservableCollection<LocalMusicSearchResultItemViewModel> Results { get; } = new();
+    public ObservableCollection<GroupedSearchResultItemViewModel> Results { get; } = new();
 
     public bool HasResults => Results.Count > 0;
     public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
@@ -81,12 +81,17 @@ public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDispos
 
         try
         {
-            var results = await _localMusicLibraryService.SearchTracksAsync(keyword, cancellation.Token);
+            var results = await _localMusicLibraryService.SearchDistinctTracksAsync(keyword, cancellation.Token);
             if (searchVersion != _searchVersion || cancellation.IsCancellationRequested)
                 return;
 
             foreach (var result in results)
-                Results.Add(new LocalMusicSearchResultItemViewModel(result));
+            {
+                Results.Add(new GroupedSearchResultItemViewModel(
+                    _localMusicLibraryService,
+                    result,
+                    _openResultAction));
+            }
 
             NotifyResultStateChanged();
         }
@@ -106,16 +111,6 @@ public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDispos
                 NotifyResultStateChanged();
             }
         }
-    }
-
-    [RelayCommand]
-    private async Task OpenResultAsync(LocalMusicSearchResultItemViewModel? item)
-    {
-        if (item is null || IsSearching)
-            return;
-
-        CancelPendingSearch();
-        await _openResultAction(item.Result);
     }
 
     [RelayCommand]
@@ -146,10 +141,19 @@ public partial class LocalMusicSearchDialogViewModel : ObservableObject, IDispos
     }
 }
 
-public sealed class LocalMusicSearchResultItemViewModel
+public partial class GroupedSearchResultItemViewModel : ObservableObject
 {
-    public LocalMusicSearchResultItemViewModel(LocalTrackSearchResult result)
+    private readonly ILocalMusicLibraryService _libraryService;
+    private readonly Func<LocalTrackSearchResult, Task> _openResultAction;
+    private bool _playlistsLoaded;
+
+    public GroupedSearchResultItemViewModel(
+        ILocalMusicLibraryService libraryService,
+        LocalTrackSearchResult result,
+        Func<LocalTrackSearchResult, Task> openResultAction)
     {
+        _libraryService = libraryService;
+        _openResultAction = openResultAction;
         Result = result;
         Cover = ResolveCover(result.Track);
     }
@@ -158,9 +162,85 @@ public sealed class LocalMusicSearchResultItemViewModel
     public string Title => Result.Track.Title;
     public string Artist => Result.Track.Artist;
     public string Album => string.IsNullOrWhiteSpace(Result.Track.Album) ? "未知专辑" : Result.Track.Album;
-    public string PlaylistName => Result.PlaylistName;
     public double DurationSeconds => Result.Track.DurationSeconds;
     public string Cover { get; }
+    public long TrackId => Result.Track.Id;
+
+    [ObservableProperty]
+    public partial bool IsExpanded { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsLoadingPlaylists { get; set; }
+
+    public ObservableCollection<PlaylistSummaryItem> Playlists { get; } = new();
+
+    [RelayCommand]
+    private async Task ToggleExpandAsync() {
+        IsExpanded = !IsExpanded;
+        if (!IsExpanded)
+            return;
+
+        if (_playlistsLoaded)
+            return;
+
+        IsLoadingPlaylists = true;
+        try
+        {
+            var playlists = await _libraryService.GetTrackPlaylistsAsync(TrackId);
+            Playlists.Clear();
+            foreach (var p in playlists)
+            {
+                Playlists.Add(new PlaylistSummaryItem
+                {
+                    PlaylistId = p.Id,
+                    PlaylistName = p.Name,
+                    PlaylistCover = ResolvePlaylistCover(p.CoverPath),
+                    TrackCount = p.TrackCount,
+                    Track = Result.Track
+                });
+            }
+
+            _playlistsLoaded = true;
+        }
+        finally
+        {
+            IsLoadingPlaylists = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenPlaylistAsync(PlaylistSummaryItem? item)
+    {
+        if (item is null)
+            return;
+
+        var searchResult = new LocalTrackSearchResult(
+            item.Track,
+            item.PlaylistId,
+            item.PlaylistName,
+            0);
+
+        await _openResultAction(searchResult);
+    }
+
+    private static string ResolvePlaylistCover(string? coverPath)
+    {
+        const string defaultPlaylistCover = "avares://KugouAvaloniaPlayer/Assets/default_listcard.png";
+
+        if (string.IsNullOrWhiteSpace(coverPath))
+            return defaultPlaylistCover;
+
+        if (LocalImageSourceHelper.TryGetEmbeddedCoverFilePath(coverPath, out _))
+            return coverPath;
+
+        if (Uri.TryCreate(coverPath, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == "avares"))
+        {
+            return coverPath;
+        }
+
+        return File.Exists(coverPath) ? new Uri(coverPath).AbsoluteUri : defaultPlaylistCover;
+    }
 
     private static string ResolveCover(LocalTrackItem track)
     {
@@ -182,4 +262,13 @@ public sealed class LocalMusicSearchResultItemViewModel
             ? defaultSongCover
             : LocalImageSourceHelper.BuildEmbeddedCoverSource(track.LocalPath);
     }
+}
+
+public sealed class PlaylistSummaryItem
+{
+    public long PlaylistId { get; init; }
+    public string PlaylistName { get; init; } = "";
+    public string PlaylistCover { get; init; } = "";
+    public int TrackCount { get; init; }
+    public LocalTrackItem Track { get; init; } = null!;
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SongItem.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SongItem.cs
@@ -88,6 +88,12 @@ public partial class SongItem : ObservableObject
     }
 
     [RelayCommand]
+    private void SearchLocalPlaylists()
+    {
+        WeakReferenceMessenger.Default.Send(new ShowTrackPlaylistSearchDialogMessage(this));
+    }
+
+    [RelayCommand]
     private void ViewSinger(SingerLite? singer)
     {
         if (singer != null)

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/TrackPlaylistSearchDialogViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/TrackPlaylistSearchDialogViewModel.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using KugouAvaloniaPlayer.Converters;
+using KugouAvaloniaPlayer.Services;
+
+namespace KugouAvaloniaPlayer.ViewModels;
+
+public partial class TrackPlaylistSearchDialogViewModel : ObservableObject, IDisposable
+{
+    private readonly ILocalMusicLibraryService _localMusicLibraryService;
+    private readonly Func<LocalTrackSearchResult, Task> _openResultAction;
+    private readonly Action _cancelAction;
+    private bool _playlistsLoaded;
+
+    public TrackPlaylistSearchDialogViewModel(
+        ILocalMusicLibraryService localMusicLibraryService,
+        SongItem song,
+        Func<LocalTrackSearchResult, Task> openResultAction,
+        Action cancelAction)
+    {
+        _localMusicLibraryService = localMusicLibraryService;
+        _openResultAction = openResultAction;
+        _cancelAction = cancelAction;
+
+        Title = song.Name;
+        Artist = song.Singer;
+        Album = string.IsNullOrWhiteSpace(song.AlbumName) ? "未知专辑" : song.AlbumName;
+        Duration = song.DurationSeconds;
+        Cover = song.Cover ?? "avares://KugouAvaloniaPlayer/Assets/default_song.png";
+        TrackId = song.LocalTrackId;
+
+        _ = LoadPlaylistsAsync();
+    }
+
+    public string Title { get; }
+    public string Artist { get; }
+    public string Album { get; }
+    public double Duration { get; }
+    public string Cover { get; }
+    public long TrackId { get; }
+
+    public ObservableCollection<TrackPlaylistItem> Playlists { get; } = new();
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    private async Task LoadPlaylistsAsync()
+    {
+        if (_playlistsLoaded)
+            return;
+
+        IsLoading = true;
+        try
+        {
+            var playlists = await _localMusicLibraryService.GetTrackPlaylistsAsync(TrackId);
+            Playlists.Clear();
+            foreach (var p in playlists)
+            {
+                Playlists.Add(new TrackPlaylistItem
+                {
+                    PlaylistId = p.Id,
+                    PlaylistName = p.Name,
+                    PlaylistCover = ResolvePlaylistCover(p.CoverPath),
+                    TrackCount = p.TrackCount
+                });
+            }
+
+            _playlistsLoaded = true;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenPlaylistAsync(TrackPlaylistItem? item)
+    {
+        if (item is null)
+            return;
+
+        var searchResult = new LocalTrackSearchResult(
+            new LocalTrackItem(
+                TrackId,
+                Title,
+                Artist,
+                Album,
+                Duration,
+                string.Empty,
+                string.Empty,
+                null,
+                null),
+            item.PlaylistId,
+            item.PlaylistName,
+            0);
+
+        _cancelAction();
+        await _openResultAction(searchResult);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _cancelAction();
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    private static string ResolvePlaylistCover(string? coverPath)
+    {
+        const string defaultPlaylistCover = "avares://KugouAvaloniaPlayer/Assets/default_listcard.png";
+
+        if (string.IsNullOrWhiteSpace(coverPath))
+            return defaultPlaylistCover;
+
+        if (LocalImageSourceHelper.TryGetEmbeddedCoverFilePath(coverPath, out _))
+            return coverPath;
+
+        if (Uri.TryCreate(coverPath, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == "avares"))
+        {
+            return coverPath;
+        }
+
+        return File.Exists(coverPath) ? new Uri(coverPath).AbsoluteUri : defaultPlaylistCover;
+    }
+}
+
+public sealed class TrackPlaylistItem
+{
+    public long PlaylistId { get; init; }
+    public string PlaylistName { get; init; } = "";
+    public string PlaylistCover { get; init; } = "";
+    public int TrackCount { get; init; }
+}

--- a/src/Apps/KugouAvaloniaPlayer/Views/LocalMusicLibraryView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/LocalMusicLibraryView.axaml
@@ -16,7 +16,7 @@
                         IsVisible="{Binding IsLocalLibraryHome}">
             <Grid RowDefinitions="Auto,*">
                 <Grid Grid.Row="0"
-                      ColumnDefinitions="*,Auto,Auto,Auto,Auto"
+                      ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto"
                       ColumnSpacing="10"
                       Margin="0,0,0,18">
                     <StackPanel Spacing="4">
@@ -29,6 +29,18 @@
                             Classes="Basic"
                             MinHeight="36"
                             Padding="14,0"
+                            Command="{Binding ShowLocalMusicSearchDialogCommand}"
+                            Cursor="Hand">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <PathIcon Data="{x:Static suki:Icons.Search}" />
+                            <TextBlock Text="搜索本地歌曲" />
+                        </StackPanel>
+                    </Button>
+
+                    <Button Grid.Column="2"
+                            Classes="Basic"
+                            MinHeight="36"
+                            Padding="14,0"
                             Command="{Binding RefreshLocalLibraryCommand}"
                             IsEnabled="{Binding !IsRefreshingLocalLibrary}"
                             Cursor="Hand">
@@ -38,7 +50,7 @@
                         </StackPanel>
                     </Button>
 
-                    <Button Grid.Column="2"
+                    <Button Grid.Column="3"
                             Classes="Basic"
                             MinHeight="36"
                             Padding="14,0"
@@ -50,7 +62,7 @@
                         </StackPanel>
                     </Button>
 
-                    <Button Grid.Column="3"
+                    <Button Grid.Column="4"
                             Classes="Basic"
                             MinHeight="36"
                             Padding="14,0"
@@ -63,7 +75,7 @@
                         </StackPanel>
                     </Button>
 
-                    <Button Grid.Column="4"
+                    <Button Grid.Column="5"
                             Classes="Basic"
                             MinHeight="36"
                             Padding="14,0"
@@ -115,6 +127,7 @@
             Cover="{Binding SelectedPlaylist.Cover}"
             Title="{Binding SelectedPlaylist.Name}"
             Songs="{Binding SelectedPlaylistSongs}"
+            SongLocateRequest="{Binding PendingSongLocateRequest}"
             BackCommand="{Binding BackFromPlaylistCommand}"
             IsLoadingMore="{Binding IsLoadingMore}"
             ListMargin="0"


### PR DESCRIPTION
在本地音乐库->搜索本地歌曲 进行模糊搜索，输入歌曲/歌手/专辑进行歌曲匹配，并搜索所在歌单；
任意本地歌曲右键->查找所在歌单 进行精确搜索，列出所在的歌单。