### PR TITLE
fix: 修复无代理环境下歌词/封面加载失败(IPv6 黑洞 + /v1/search 空响应回退老接口)

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/App.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Http;
 using AsyncImageLoader;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -149,6 +150,7 @@ public partial class App : Application
         _imageLoader = new BoundedDiskCachedWebImageLoader(
             cacheFolder,
             TimeSpan.FromDays(7),
+            httpClient: new HttpClient(KuGou.Net.Infrastructure.Http.KgPrimaryHandler.Create()),
             maxMemoryEntries: 200,
             maxMemoryBytes: 32L * 1024 * 1024,
             maxDiskBytes: 256L * 1024 * 1024);

--- a/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
@@ -119,12 +119,7 @@ public sealed partial class AvaloniaAppServiceProvider
 
     private static HttpClient CreateHttpClient(CookieContainer cookieContainer, KgSignatureHandler signatureHandler)
     {
-        var primaryHandler = new HttpClientHandler
-        {
-            UseCookies = true,
-            CookieContainer = cookieContainer,
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-        };
+        var primaryHandler = KgPrimaryHandler.Create(cookieContainer);
 
         signatureHandler.InnerHandler = primaryHandler;
 

--- a/src/Apps/KugouAvaloniaPlayer/Services/BoundedDiskCachedWebImageLoader.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/BoundedDiskCachedWebImageLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Enumeration;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -17,10 +18,11 @@ namespace KugouAvaloniaPlayer.Services;
 public sealed class BoundedDiskCachedWebImageLoader(
     string cacheFolder,
     TimeSpan diskCacheLifetime,
+    HttpClient? httpClient = null,
     int maxMemoryEntries = BoundedDiskCachedWebImageLoader.DefaultMaxMemoryEntries,
     long maxMemoryBytes = BoundedDiskCachedWebImageLoader.DefaultMaxMemoryBytes,
     long maxDiskBytes = BoundedDiskCachedWebImageLoader.DefaultMaxDiskBytes)
-    : BaseWebImageLoader
+    : BaseWebImageLoader(httpClient ?? new HttpClient(), disposeHttpClient: httpClient == null)
 {
     private const int DefaultMaxMemoryEntries = 200;
     private const long DefaultMaxMemoryBytes = 32L * 1024 * 1024;

--- a/src/Apps/KugouAvaloniaPlayer/Services/SimpleHttpClientFactory.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/SimpleHttpClientFactory.cs
@@ -1,11 +1,15 @@
 using System.Net.Http;
+using KuGou.Net.Infrastructure.Http;
 
 namespace KugouAvaloniaPlayer.Services;
 
 public sealed class SimpleHttpClientFactory : IHttpClientFactory
 {
+    // 共享底层 handler,避免每次 CreateClient 都新建连接池
+    private static readonly SocketsHttpHandler SharedHandler = KgPrimaryHandler.Create();
+
     public HttpClient CreateClient(string name)
     {
-        return new HttpClient();
+        return new HttpClient(SharedHandler, disposeHandler: false);
     }
 }

--- a/src/Libraries/KuGou.Net/Infrastructure/Http/KgHttpClientFactory.cs
+++ b/src/Libraries/KuGou.Net/Infrastructure/Http/KgHttpClientFactory.cs
@@ -36,12 +36,7 @@ public static class KgHttpClientFactory
                              ?? new KgSessionManager(new CookieContainer(),
                                  sessionPersistence ?? new InMemorySessionPersistence());
 
-        var primaryHandler = new HttpClientHandler
-        {
-            UseCookies = false,
-            // CookieContainer = cookieContainer, 
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-        };
+        var primaryHandler = KgPrimaryHandler.Create();
 
 
         var signatureHandler = new KgSignatureHandler(sessionManager)

--- a/src/Libraries/KuGou.Net/Infrastructure/Http/KgPrimaryHandler.cs
+++ b/src/Libraries/KuGou.Net/Infrastructure/Http/KgPrimaryHandler.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace KuGou.Net.Infrastructure.Http;
+
+/// <summary>
+///     构建底层 SocketsHttpHandler，连接时 IPv4 优先。
+///     部分网络（如校园网）的 IPv6 链路对酷狗 CDN 是 TCP 黑洞，默认按 DNS 返回顺序
+///     先试 IPv6 会让请求挂起直到超时；这里固定先连 IPv4，全部失败再用 IPv6 兜底。
+/// </summary>
+public static class KgPrimaryHandler
+{
+    private static readonly TimeSpan ConnectTimeoutPerAddress = TimeSpan.FromSeconds(5);
+
+    public static SocketsHttpHandler Create(CookieContainer? cookieContainer = null)
+    {
+        return new SocketsHttpHandler
+        {
+            UseCookies = cookieContainer != null,
+            CookieContainer = cookieContainer ?? new CookieContainer(),
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ConnectCallback = ConnectPreferingIpv4
+        };
+    }
+
+    private static async ValueTask<Stream> ConnectPreferingIpv4(
+        SocketsHttpConnectionContext context,
+        CancellationToken cancellationToken)
+    {
+        var addresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken);
+
+        var ipv4 = addresses.Where(a => a.AddressFamily == AddressFamily.InterNetwork).ToArray();
+        var ipv6 = addresses.Where(a => a.AddressFamily == AddressFamily.InterNetworkV6).ToArray();
+        var ordered = ipv4.Length > 0 ? ipv4.Concat(ipv6).ToArray() : addresses;
+
+        Exception? lastError = null;
+        foreach (var address in ordered)
+        {
+            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try
+            {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(ConnectTimeoutPerAddress);
+                await socket.ConnectAsync(address, context.DnsEndPoint.Port, timeoutCts.Token);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                socket.Dispose();
+                throw;
+            }
+            catch (Exception ex) when (ex is SocketException or OperationCanceledException)
+            {
+                socket.Dispose();
+                lastError = ex;
+            }
+        }
+
+        throw lastError ?? new SocketException((int)SocketError.HostNotFound);
+    }
+}

--- a/src/Libraries/KuGou.Net/Infrastructure/KuGouComposition.cs
+++ b/src/Libraries/KuGou.Net/Infrastructure/KuGouComposition.cs
@@ -29,12 +29,7 @@ public sealed partial class KuGouComposition
 
     private static HttpClient CreateHttpClient(CookieContainer cookieContainer, KgSignatureHandler signatureHandler)
     {
-        var primaryHandler = new HttpClientHandler
-        {
-            UseCookies = true,
-            CookieContainer = cookieContainer,
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-        };
+        var primaryHandler = KgPrimaryHandler.Create(cookieContainer);
 
         signatureHandler.InnerHandler = primaryHandler;
 

--- a/src/Libraries/KuGou.Net/Protocol/Raw/RawLyricApi.cs
+++ b/src/Libraries/KuGou.Net/Protocol/Raw/RawLyricApi.cs
@@ -35,7 +35,42 @@ public class RawLyricApi(IKgTransport transport)
             SignatureType = SignatureType.Default
         };
 
-        return await transport.SendAsync(request);
+        var result = await transport.SendAsync(request);
+
+        // /v1/search 对部分直连 IP 返回 200 + 空响应（IP 风控），此时回退到老接口 /search。
+        // 两个接口的响应结构一致（candidates[].id/accesskey），老接口无 fmt 字段，调用方默认按 krc 处理。
+        if (!HasCandidates(result))
+            result = await transport.SendAsync(BuildLegacySearchRequest(hash, keyword));
+
+        return result;
+    }
+
+    private static KgRequest BuildLegacySearchRequest(string? hash, string? keyword)
+    {
+        return new KgRequest
+        {
+            Method = HttpMethod.Get,
+            BaseUrl = LyricHost,
+            Path = "/search",
+            Params = new Dictionary<string, string>
+            {
+                { "ver", "1" },
+                { "man", "yes" },
+                { "client", "pc" },
+                { "duration", "0" },
+                { "hash", hash ?? "" },
+                { "keyword", keyword ?? "" }
+            },
+            SignatureType = SignatureType.Default
+        };
+    }
+
+    private static bool HasCandidates(JsonElement json)
+    {
+        return json.ValueKind == JsonValueKind.Object
+               && json.TryGetProperty("candidates", out var candidates)
+               && candidates.ValueKind == JsonValueKind.Array
+               && candidates.GetArrayLength() > 0;
     }
 
     /// <summary>


### PR DESCRIPTION
## 问题背景

在 **IPv6 到酷狗 CDN 为黑洞、且未开启系统代理** 的网络环境下(校园网十分典型),歌词与封面完全无法加载。日志中表现为 `获取在线歌词失败`,`TaskCanceledException: HttpClient.Timeout of 100 seconds elapsing`。开启系统代理后一切正常。

## 根因分析(两层问题叠加)

**1. IPv6 连接黑洞(网络层主因)**

`lyrics.kugou.com` / `imge.kugou.com` 均通过 `dnsv1.com` CDN 解析出 AAAA + A 记录。在部分网络下 IPv6 链路对 CDN 是 TCP 黑洞(连接不发 RST 也不通)。.NET `SocketsHttpHandler` 默认按 DNS 返回顺序连接,会优先尝试 IPv6 并挂起直到 100s 超时,期间不会回落 IPv4。实测(curl 有 Happy Eyeballs 快速回落,因此浏览器/curl 正常;HttpClient 无此机制):

```
curl -6 https://lyrics.kugou.com → 超时 (exit 28)
curl -4 https://lyrics.kugou.com → 200, 0.3s
```

**2. `/v1/search` 对部分出口 IP 返回空响应(接口风控)**

即使网络连通,`lyrics.kugou.com/v1/search` 对校园网共享出口 IP 会返回 `HTTP 200 + 空 body`(传输层此时反序列化为 `{}`,调用方静默无歌词)。实测老接口 `GET /search?ver=1&man=yes&client=pc&...` 对同一 IP 正常返回,且两者响应结构一致(`candidates[].id/accesskey`),老接口无 `fmt` 字段、调用方默认 krc,天然兼容。

## 修复内容

- **新增 `KgPrimaryHandler`**(`KuGou.Net/Infrastructure/Http`):通过 `ConnectCallback` 实现 **IPv4 优先连接**(每个地址 5s 连接超时;IPv4 全部失败后才尝试 IPv6 兜底),统一替换以下 5 处的底层 handler:
  - `KuGouComposition.CreateHttpClient`(库 DI 路径)
  - `AvaloniaAppServiceProvider.CreateHttpClient`(播放器主链路,歌词/搜索实际走这里)
  - `KgHttpClientFactory.Create`(终端版 / Native)
  - `App.ConfigureImageLoader` → `BoundedDiskCachedWebImageLoader`(封面 CDN 请求,新增可选 `httpClient` 参数注入)
  - `SimpleHttpClientFactory`(SMTC 等用途,共享静态 handler)
- **`RawLyricApi.SearchLyricAsync`**:`/v1/search` 返回空候选时自动回退老接口 `/search`(构建请求的参数保持最小集合,签名层附加参数已验证不影响老接口)。

## 验证(全程无代理直连)

模拟与 App 完全一致的调用链(歌曲搜索拿 hash → 歌词搜索 → 下载解密),4 首歌曲全部成功,93–298ms,解密出完整 KRC(含逐字时间轴):

| 歌曲 | 结果 | 耗时 |
|---|---|---|
| 周杰伦 - 告白气球 | ✅ 5211 字符 | 298ms |
| BEYOND - 海阔天空 | ✅ 5644 字符 | 121ms |
| 周杰伦 - 晴天 | ✅ 8405 字符 | 93ms |
| 陈奕迅 - 孤勇者 | ✅ 8484 字符 | 99ms |

修复前:同环境下 `获取在线歌词失败`(100s 超时)、封面无法加载。

## 兼容性说明

- 未开启代理的正常网络不受影响(IPv4 本来就能通,优先连接只改变尝试顺序);
- `KgPrimaryHandler` 保留系统代理行为(`HttpClientHandler` 的代理默认值),仅接管 DNS 连接排序;
- 歌词回退仅在 v1 空候选时触发,老接口响应结构与现有解析逻辑完全兼容,其他调用方(`LyricsService`、`TerminalLyricsService`、`LyricController`)无需改动。
