### PR TITLE
feat：每日推荐刷新、相似歌曲推荐、Toast/弹窗 ✕ 关闭、FM 第三推荐池

### DIFF
--- a/src/Apps/KugouAvaloniaPlayer/Controls/AddToPlaylistDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/AddToPlaylistDialog.axaml
@@ -61,7 +61,7 @@
             Background="{DynamicResource SukiBackground}"
             CornerRadius="18">
         <Grid RowDefinitions="Auto,Auto,*,Auto">
-            <Grid ColumnDefinitions="Auto,*"
+            <Grid ColumnDefinitions="Auto,*,Auto"
                   Margin="0,0,0,18">
                 <Border Width="72"
                         Height="72"
@@ -89,6 +89,17 @@
                                Foreground="{DynamicResource SukiLowText}"
                                TextTrimming="CharacterEllipsis" />
                 </StackPanel>
+
+                <Button Grid.Column="2"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Right"
+                        Padding="8,4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        FontSize="18"
+                        Command="{Binding CancelCommand}"
+                        Content="✕" />
             </Grid>
 
             <Grid Row="1"
@@ -203,20 +214,13 @@
             </Grid>
 
             <Grid Row="3"
-                  ColumnDefinitions="*,Auto,Auto"
+                  ColumnDefinitions="*,Auto"
                   Margin="0,18,0,0">
                 <TextBlock Text="{Binding SelectedPlaylist.Name, StringFormat='已选择：{0}', FallbackValue='已选择：'}"
                            VerticalAlignment="Center"
                            Foreground="{DynamicResource SukiLowText}" />
 
                 <Button Grid.Column="1"
-                        Command="{Binding CancelCommand}"
-                        Classes="Basic"
-                        Margin="0,0,10,0">
-                    <TextBlock Text="取消" />
-                </Button>
-
-                <Button Grid.Column="2"
                         Command="{Binding ConfirmCommand}"
                         Classes="Standard"
                         IsEnabled="{Binding CanConfirm}"

--- a/src/Apps/KugouAvaloniaPlayer/Controls/LyricMatchDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/LyricMatchDialog.axaml
@@ -8,7 +8,19 @@
              x:DataType="vm:LyricMatchDialogViewModel">
     <Border Padding="20" Background="{DynamicResource SukiBackground}" CornerRadius="18">
         <Grid RowDefinitions="Auto,*,Auto" MinWidth="440" MaxWidth="600">
-            <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" Margin="0,0,0,14" />
+            <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,14">
+                <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" />
+                <Button Grid.Column="1"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Right"
+                        Padding="8,4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        FontSize="18"
+                        Command="{Binding CancelCommand}"
+                        Content="✕" />
+            </Grid>
 
             <ListBox Grid.Row="1"
                      ItemsSource="{Binding Results}"
@@ -46,9 +58,6 @@
 
             <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right"
                         Spacing="8" Margin="0,14,0,0">
-                <Button Classes="Basic" Command="{Binding CancelCommand}" Cursor="Hand">
-                    <TextBlock Text="关闭" />
-                </Button>
                 <Button Command="{Binding UseTemporaryCommand}" Cursor="Hand">
                     <TextBlock Text="临时匹配" />
                 </Button>

--- a/src/Apps/KugouAvaloniaPlayer/Controls/MultiPlaylistSelectionDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/MultiPlaylistSelectionDialog.axaml
@@ -49,14 +49,27 @@
             Background="{DynamicResource SukiBackground}"
             CornerRadius="18">
         <Grid RowDefinitions="Auto,Auto,*,Auto">
-            <StackPanel Spacing="4"
-                        Margin="0,0,0,18">
-                <TextBlock Text="添加到歌单"
-                           FontSize="24"
-                           FontWeight="Bold" />
-                <TextBlock Text="{Binding SongCount, StringFormat='将 {0} 首歌曲添加到一个或多个在线歌单'}"
-                           Foreground="{DynamicResource SukiLowText}" />
-            </StackPanel>
+            <Grid ColumnDefinitions="*,Auto"
+                  Margin="0,0,0,18">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="添加到歌单"
+                               FontSize="24"
+                               FontWeight="Bold" />
+                    <TextBlock Text="{Binding SongCount, StringFormat='将 {0} 首歌曲添加到一个或多个在线歌单'}"
+                               Foreground="{DynamicResource SukiLowText}" />
+                </StackPanel>
+
+                <Button Grid.Column="1"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Right"
+                        Padding="8,4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        FontSize="18"
+                        Command="{Binding CancelCommand}"
+                        Content="✕" />
+            </Grid>
 
             <Grid Row="1"
                   ColumnDefinitions="*,Auto,Auto,Auto"
@@ -183,7 +196,7 @@
             </Grid>
 
             <Grid Row="3"
-                  ColumnDefinitions="*,Auto,Auto"
+                  ColumnDefinitions="*,Auto"
                   ColumnSpacing="10"
                   Margin="0,18,0,0">
                 <TextBlock Text="{Binding SelectedCount, StringFormat='已选择 {0} 个歌单'}"
@@ -191,12 +204,6 @@
                            Foreground="{DynamicResource SukiLowText}" />
 
                 <Button Grid.Column="1"
-                        Command="{Binding CancelCommand}"
-                        Classes="Basic">
-                    <TextBlock Text="取消" />
-                </Button>
-
-                <Button Grid.Column="2"
                         Command="{Binding ConfirmCommand}"
                         Classes="Standard"
                         IsEnabled="{Binding CanConfirm}"

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongBatchActionDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongBatchActionDialog.axaml
@@ -43,14 +43,27 @@
             Background="{DynamicResource SukiBackground}"
             CornerRadius="18">
         <Grid RowDefinitions="Auto,Auto,*,Auto">
-            <StackPanel Spacing="6"
-                        Margin="0,0,0,16">
-                <TextBlock Text="批量操作"
-                           FontSize="26"
-                           FontWeight="Bold" />
-                <TextBlock Text="{Binding TotalSongCount, StringFormat='当前详情页已加载 {0} 首歌曲，可搜索并多选后执行操作'}"
-                           Foreground="{DynamicResource SukiLowText}" />
-            </StackPanel>
+            <Grid ColumnDefinitions="*,Auto"
+                  Margin="0,0,0,16">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="批量操作"
+                               FontSize="26"
+                               FontWeight="Bold" />
+                    <TextBlock Text="{Binding TotalSongCount, StringFormat='当前详情页已加载 {0} 首歌曲，可搜索并多选后执行操作'}"
+                               Foreground="{DynamicResource SukiLowText}" />
+                </StackPanel>
+
+                <Button Grid.Column="1"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Right"
+                        Padding="8,4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        FontSize="18"
+                        Command="{Binding CancelCommand}"
+                        Content="✕" />
+            </Grid>
 
             <Grid Row="1"
                   ColumnDefinitions="*,Auto,Auto,Auto"
@@ -162,7 +175,7 @@
             </Grid>
 
             <Grid Row="3"
-                  ColumnDefinitions="*,Auto,Auto,Auto,Auto"
+                  ColumnDefinitions="*,Auto,Auto,Auto"
                   ColumnSpacing="10"
                   Margin="0,18,0,0">
                 <TextBlock Text="{Binding SelectedCount, StringFormat='已选择 {0} 首歌曲'}"
@@ -170,13 +183,6 @@
                            Foreground="{DynamicResource SukiLowText}" />
 
                 <Button Grid.Column="1"
-                        Command="{Binding CancelCommand}"
-                        Classes="Basic"
-                        Cursor="Hand">
-                    <TextBlock Text="取消" />
-                </Button>
-
-                <Button Grid.Column="2"
                         Command="{Binding AddToQueueCommand}"
                         Classes="Basic"
                         Cursor="Hand"
@@ -184,7 +190,7 @@
                     <TextBlock Text="添加到播放列表" />
                 </Button>
 
-                <Button Grid.Column="3"
+                <Button Grid.Column="2"
                         Command="{Binding AddToPlaylistCommand}"
                         Classes="Standard"
                         Cursor="Hand"
@@ -204,7 +210,7 @@
                     </Grid>
                 </Button>
 
-                <Button Grid.Column="4"
+                <Button Grid.Column="3"
                         Command="{Binding PlaySelectedCommand}"
                         Classes="Standard"
                         Cursor="Hand"

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml
@@ -309,6 +309,8 @@
                                     AddToNextCommand="{Binding #Root.AddToNextCommand}"
                                     ShowPlaylistDialogCommand="{Binding #Root.ShowPlaylistDialogCommand}"
                                     ViewSingerCommand="{Binding #Root.ViewSingerCommand}"
+                                    ShowSimilarSongsCommand="{Binding #Root.ShowSimilarSongsCommand}"
+                                    SearchSongCommand="{Binding #Root.SearchSongCommand}"
                                     RemoveFromPlaylistCommand="{Binding #Root.RemoveSongCommand}"
                                     SetLocalCoverCommand="{Binding #Root.SetLocalSongCoverCommand}"
                                     MatchLocalLyricsCommand="{Binding #Root.MatchLocalLyricsCommand}"

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongCollectionDetailView.axaml.cs
@@ -186,6 +186,8 @@ public partial class SongCollectionDetailView : UserControl
         ShowPlaylistDialogCommand = new AsyncRelayCommand<SongItem?>(ShowPlaylistDialogAsync);
         MatchLocalLyricsCommand = new AsyncRelayCommand<SongItem?>(MatchLocalLyricsAsync);
         ViewSingerCommand = new RelayCommand<SingerLite?>(ViewSinger);
+        ShowSimilarSongsCommand = new RelayCommand<SongItem?>(ShowSimilarSongs);
+        SearchSongCommand = new RelayCommand<SongItem?>(SearchSong);
         InitializeComponent();
         UpdateCurrentHeroBackground();
     }
@@ -198,6 +200,8 @@ public partial class SongCollectionDetailView : UserControl
     public ICommand ShowPlaylistDialogCommand { get; }
     public ICommand MatchLocalLyricsCommand { get; }
     public ICommand ViewSingerCommand { get; }
+    public ICommand ShowSimilarSongsCommand { get; }
+    public ICommand SearchSongCommand { get; }
 
     public string? Cover
     {
@@ -595,6 +599,18 @@ public partial class SongCollectionDetailView : UserControl
     {
         if (singer != null)
             SongInteractions?.NavigateToSinger(singer);
+    }
+
+    private void ShowSimilarSongs(SongItem? song)
+    {
+        if (song != null)
+            SongInteractions?.NavigateToSimilarSongs(song);
+    }
+
+    private void SearchSong(SongItem? song)
+    {
+        if (song != null)
+            SongInteractions?.SearchSong(song, KugouAvaloniaPlayer.Models.SearchType.Playlist);
     }
 
     private void ScrollToPlayingSong()

--- a/src/Apps/KugouAvaloniaPlayer/Controls/SongListItemControl.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/SongListItemControl.axaml.cs
@@ -24,6 +24,12 @@ public partial class SongListItemControl : UserControl
     public static readonly StyledProperty<ICommand?> ViewSingerCommandProperty =
         AvaloniaProperty.Register<SongListItemControl, ICommand?>(nameof(ViewSingerCommand));
 
+    public static readonly StyledProperty<ICommand?> ShowSimilarSongsCommandProperty =
+        AvaloniaProperty.Register<SongListItemControl, ICommand?>(nameof(ShowSimilarSongsCommand));
+
+    public static readonly StyledProperty<ICommand?> SearchSongCommandProperty =
+        AvaloniaProperty.Register<SongListItemControl, ICommand?>(nameof(SearchSongCommand));
+
     public static readonly StyledProperty<ICommand?> RemoveFromPlaylistCommandProperty =
         AvaloniaProperty.Register<SongListItemControl, ICommand?>(nameof(RemoveFromPlaylistCommand));
 
@@ -67,6 +73,18 @@ public partial class SongListItemControl : UserControl
     {
         get => GetValue(ViewSingerCommandProperty);
         set => SetValue(ViewSingerCommandProperty, value);
+    }
+
+    public ICommand? ShowSimilarSongsCommand
+    {
+        get => GetValue(ShowSimilarSongsCommandProperty);
+        set => SetValue(ShowSimilarSongsCommandProperty, value);
+    }
+
+    public ICommand? SearchSongCommand
+    {
+        get => GetValue(SearchSongCommandProperty);
+        set => SetValue(SearchSongCommandProperty, value);
     }
 
     public ICommand? RemoveFromPlaylistCommand
@@ -152,6 +170,23 @@ public partial class SongListItemControl : UserControl
             Command = AddToNextCommand,
             CommandParameter = song
         });
+
+        if (song.LocalFilePath is null)
+        {
+            flyout.Items.Add(new MenuItem
+            {
+                Header = "相似歌曲推荐",
+                Command = ShowSimilarSongsCommand,
+                CommandParameter = song
+            });
+
+            flyout.Items.Add(new MenuItem
+            {
+                Header = "搜索相关歌单",
+                Command = SearchSongCommand,
+                CommandParameter = song
+            });
+        }
 
         if (song.LocalFilePath is null)
         {

--- a/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Controls/TrackPlaylistSearchDialog.axaml
@@ -38,13 +38,26 @@
             Padding="22"
             Background="{DynamicResource SukiBackground}"
             CornerRadius="18">
-        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
-            <StackPanel Spacing="6"
-                        Margin="0,0,0,16">
-                <TextBlock Text="精确歌单检索"
-                           FontSize="24"
-                           FontWeight="Bold" />
-            </StackPanel>
+        <Grid RowDefinitions="Auto,Auto,Auto,*">
+            <Grid ColumnDefinitions="*,Auto"
+                  Margin="0,0,0,16">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="精确歌单检索"
+                               FontSize="24"
+                               FontWeight="Bold" />
+                </StackPanel>
+
+                <Button Grid.Column="1"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Right"
+                        Padding="8,4"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        FontSize="18"
+                        Command="{Binding CancelCommand}"
+                        Content="✕" />
+            </Grid>
 
             <suki:GlassCard Grid.Row="1"
                             Padding="12"
@@ -141,15 +154,6 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-
-            <Button Grid.Row="4"
-                    Classes="Basic"
-                    Command="{Binding CancelCommand}"
-                    Cursor="Hand"
-                    HorizontalAlignment="Right"
-                    Margin="0,14,0,0">
-                <TextBlock Text="关闭" />
-            </Button>
         </Grid>
     </Border>
 </UserControl>

--- a/src/Apps/KugouAvaloniaPlayer/Models/ApplicationEvents.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Models/ApplicationEvents.cs
@@ -8,6 +8,13 @@ public sealed record PlaylistCollectionChangedEvent(
 
 public sealed record SongLocateRequest(long LocalTrackId, long Sequence);
 
+/// <summary>
+///     请求跳转到搜索页并执行搜索（用于歌曲右键"搜索"等入口）。
+/// </summary>
+/// <param name="Keyword">搜索关键词。</param>
+/// <param name="Type">搜索分类，null 表示保持当前分类。</param>
+public sealed record SearchRequestedEvent(string Keyword, SearchType? Type = null);
+
 public enum PlaylistChangeKind
 {
     Created,

--- a/src/Apps/KugouAvaloniaPlayer/Models/PersonalFmModels.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Models/PersonalFmModels.cs
@@ -21,7 +21,8 @@ public enum PersonalFmMode
 public enum PersonalFmSongPoolId
 {
     Taste = 0,
-    Style = 1
+    Style = 1,
+    Special = 2
 }
 
 public sealed record PersonalFmSongPoolOption(PersonalFmSongPoolId Value, string Label);
@@ -80,7 +81,12 @@ public static class PersonalFmPresentation
 
     public static string GetSongPoolLabel(PersonalFmSongPoolId songPoolId)
     {
-        return songPoolId == PersonalFmSongPoolId.Style ? "根据风格" : "根据口味";
+        return songPoolId switch
+        {
+            PersonalFmSongPoolId.Style => "根据风格",
+            PersonalFmSongPoolId.Special => "特殊推荐池",
+            _ => "根据口味"
+        };
     }
 }
 

--- a/src/Apps/KugouAvaloniaPlayer/Services/AppUpdateService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/AppUpdateService.cs
@@ -49,12 +49,7 @@ public sealed class AppUpdateService(
                 if (showNoUpdateToast)
                     Dispatcher.UIThread.Post(() =>
                     {
-                        toastManager.CreateToast()
-                            .OfType(NotificationType.Information)
-                            .WithTitle("检查更新")
-                            .WithContent("应用未通过安装包安装，无法自动更新。")
-                            .Dismiss().After(TimeSpan.FromSeconds(3))
-                            .Queue();
+                        ShowSimpleToast(NotificationType.Information, "检查更新", "应用未通过安装包安装，无法自动更新。");
                     });
                 return;
             }
@@ -73,12 +68,7 @@ public sealed class AppUpdateService(
                 if (showNoUpdateToast)
                     Dispatcher.UIThread.Post(() =>
                     {
-                        toastManager.CreateToast()
-                            .OfType(NotificationType.Success)
-                            .WithTitle("检查更新")
-                            .WithContent("当前已是最新版本。")
-                            .Dismiss().After(TimeSpan.FromSeconds(3))
-                            .Queue();
+                        ShowSimpleToast(NotificationType.Success, "检查更新", "当前已是最新版本。");
                     });
                 return;
             }
@@ -91,12 +81,7 @@ public sealed class AppUpdateService(
             if (showNoUpdateToast)
                 Dispatcher.UIThread.Post(() =>
                 {
-                    toastManager.CreateToast()
-                        .OfType(NotificationType.Error)
-                        .WithTitle("检查更新失败")
-                        .WithContent(ex.Message)
-                        .Dismiss().After(TimeSpan.FromSeconds(4))
-                        .Queue();
+                    ShowSimpleToast(NotificationType.Error, "检查更新失败", ex.Message);
                 });
         }
     }
@@ -304,12 +289,7 @@ public sealed class AppUpdateService(
             Dispatcher.UIThread.Post(() =>
             {
                 toastManager.Dismiss(toast);
-                toastManager.CreateToast()
-                    .OfType(NotificationType.Error)
-                    .WithTitle("更新下载失败")
-                    .WithContent(ex.Message)
-                    .Dismiss().After(TimeSpan.FromSeconds(4))
-                    .Queue();
+                ShowSimpleToast(NotificationType.Error, "更新下载失败", ex.Message);
             });
         }
     }
@@ -365,6 +345,11 @@ public sealed class AppUpdateService(
             .WithActionButton(CreateStandardToastActionButton("稍后"), _ => { }, true)
             .WithActionButton(CreateStandardToastActionButton("立即重启"), _ => { updateManager.ApplyUpdatesAndRestart(newVersion); }, true)
             .Queue();
+    }
+
+    private void ShowSimpleToast(NotificationType type, string title, string content)
+    {
+        toastManager.ShowDismissibleToast(type, title, content);
     }
 
     private static Button CreateStandardToastActionButton(object content)

--- a/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/AvaloniaAppServiceProvider.cs
@@ -80,6 +80,7 @@ public sealed partial class AvaloniaAppServiceProvider
         .Bind<IGitHubReleaseService>().As(Singleton).To<GitHubReleaseService>()
         .Bind<IAppUpdateService>().As(Singleton).To<AppUpdateService>()
         .Bind<ISingerViewModelFactory>().To<SingerViewModelFactory>()
+        .Bind<ISimilarSongsViewModelFactory>().To<SimilarSongsViewModelFactory>()
         .Bind<IDiscoverTagViewModelFactory>().To<DiscoverTagViewModelFactory>()
         .Bind<IDesktopLyricViewModelFactory>().As(Singleton).To<DesktopLyricViewModelFactory>()
         .Bind<UserCreatedPlaylistCacheService>().As(Singleton).To<UserCreatedPlaylistCacheService>()

--- a/src/Apps/KugouAvaloniaPlayer/Services/FavoritePlaylistService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/FavoritePlaylistService.cs
@@ -628,6 +628,7 @@ public partial class FavoritePlaylistService(
                 existing.Name = string.IsNullOrWhiteSpace(song.Name) ? existing.Name : song.Name;
                 existing.Singer = string.IsNullOrWhiteSpace(song.Singer) ? existing.Singer : song.Singer;
                 existing.AlbumId = string.IsNullOrWhiteSpace(song.AlbumId) ? existing.AlbumId : song.AlbumId;
+                existing.AlbumAudioId = song.AlbumAudioId > 0 ? song.AlbumAudioId : existing.AlbumAudioId;
                 existing.Cover = string.IsNullOrWhiteSpace(song.Cover) ? existing.Cover : song.Cover;
                 existing.DurationSeconds = song.DurationSeconds > 0 ? song.DurationSeconds : existing.DurationSeconds;
                 existing.Singers = song.Singers?.AsValueEnumerable().ToList() ?? existing.Singers;
@@ -641,6 +642,7 @@ public partial class FavoritePlaylistService(
                 Name = song.Name,
                 Singer = song.Singer,
                 AlbumId = song.AlbumId,
+                AlbumAudioId = song.AlbumAudioId,
                 Cover = song.Cover,
                 DurationSeconds = song.DurationSeconds,
                 Singers = song.Singers.AsValueEnumerable().ToList()
@@ -796,6 +798,7 @@ public partial class FavoritePlaylistService(
                     Singer = s.Singers.Count > 0 ? string.Join("、", s.Singers.AsValueEnumerable().Select(x => x.Name).ToArray()) : "未知",
                     Singers = s.Singers,
                     AlbumId = s.AlbumId,
+                    AlbumAudioId = s.MixSongId,
                     Cover = s.Cover,
                     DurationSeconds = s.DurationMs / 1000.0,
                     Privilege = s.Privilege
@@ -880,6 +883,7 @@ public partial class FavoritePlaylistService(
             Singer = string.IsNullOrWhiteSpace(x.Singer) ? "未知" : x.Singer,
             Hash = x.Hash,
             AlbumId = x.AlbumId ?? "",
+            AlbumAudioId = x.AlbumAudioId,
             FileId = x.FileId,
             Singers = x.Singers ?? new List<SingerLite>(),
             Cover = string.IsNullOrWhiteSpace(x.Cover)
@@ -1170,6 +1174,7 @@ public sealed class LikeSongCacheItem
     public string Singer { get; set; } = "";
     public List<SingerLite> Singers { get; set; } = new();
     public string AlbumId { get; set; } = "";
+    public long AlbumAudioId { get; set; }
     public string? Cover { get; set; }
     public double DurationSeconds { get; set; }
     public int Privilege { get; set; }
@@ -1263,12 +1268,6 @@ partial class FavoritePlaylistService
 
     private void ShowToast(NotificationType type, string title, string content)
     {
-        toastManager.CreateToast()
-            .OfType(type)
-            .WithTitle(title)
-            .WithContent(content)
-            .Dismiss().ByClicking()
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Queue();
+        toastManager.ShowDismissibleToast(type, title, content);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/Services/ISongInteractionService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/ISongInteractionService.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls.Notifications;
+using CommunityToolkit.Mvvm.Messaging;
 using KuGou.Net.Abstractions.Models;
 using KuGou.Net.Clients;
+using KugouAvaloniaPlayer.Models;
 using KugouAvaloniaPlayer.ViewModels;
 using SukiUI.Toasts;
 
@@ -14,6 +16,10 @@ namespace KugouAvaloniaPlayer.Services;
 public interface ISongInteractionService
 {
     void NavigateToSinger(SingerLite singer);
+
+    void NavigateToSimilarSongs(SongItem song);
+
+    void SearchSong(SongItem song, SearchType type);
 
     Task ShowAddToPlaylistDialogAsync(SongItem song);
 
@@ -28,13 +34,15 @@ public sealed class SongInteractionService(
     FavoritePlaylistService favoritePlaylistService,
     IPlaybackCommands playbackCommands,
     ISingerViewModelFactory singerViewModelFactory,
+    ISimilarSongsViewModelFactory similarSongsViewModelFactory,
     INavigationService navigationService,
     SearchClient searchClient,
     ILocalSingerMatchService localSingerMatchService,
     ILocalLyricMatchService localLyricMatchService,
     LyricsService lyricsService,
-    ISukiToastManager toastManager) : ISongInteractionService {
-    
+    ISukiToastManager toastManager,
+    IMessenger messenger) : ISongInteractionService {
+
     public void NavigateToSinger(SingerLite singer) {
         if (singer.Id == -1 && !string.IsNullOrWhiteSpace(singer.Name))
             MatchLocalSingersAsync(singer)
@@ -46,6 +54,32 @@ public sealed class SongInteractionService(
                 });
         else
             navigationService.NavigateTransient(singerViewModelFactory.Create(singer.Id.ToString(), singer.Name));
+    }
+
+    public void NavigateToSimilarSongs(SongItem song) {
+        if (song.AlbumAudioId == 0) {
+            toastManager.CreateToast()
+                .OfType(NotificationType.Warning)
+                .WithTitle("相似歌曲")
+                .WithContent("当前歌曲缺少在线信息，无法推荐")
+                .Dismiss().After(TimeSpan.FromSeconds(3))
+                .Queue();
+            return;
+        }
+
+        navigationService.NavigateTransient(similarSongsViewModelFactory.Create(song));
+    }
+
+    public void SearchSong(SongItem song, SearchType type)
+    {
+        var keyword = string.IsNullOrWhiteSpace(song.Name) ? song.DisplayTitle : song.Name;
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            toastManager.ShowDismissibleToast(NotificationType.Warning, "搜索", "无法获取歌曲名称");
+            return;
+        }
+
+        messenger.Send(new SearchRequestedEvent(keyword, type));
     }
 
     public Task ShowAddToPlaylistDialogAsync(SongItem song) =>
@@ -206,14 +240,6 @@ public sealed class SongInteractionService(
 
     private void ShowToast(NotificationType type, string title, string content)
     {
-        toastManager.CreateToast()
-            .OfType(type)
-            .WithTitle(title)
-            .WithContent(content)
-            .Dismiss()
-            .ByClicking()
-            .Dismiss()
-            .After(TimeSpan.FromSeconds(3))
-            .Queue();
+        toastManager.ShowDismissibleToast(type, title, content);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/Services/LoginInitializationService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/LoginInitializationService.cs
@@ -45,12 +45,7 @@ internal sealed class LoginInitializationService(
         {
             logger.LogError(ex, "登录初始化失败");
             await Dispatcher.UIThread.InvokeAsync(() =>
-                toastManager.CreateToast()
-                    .OfType(NotificationType.Error)
-                    .WithTitle("登录初始化失败")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .WithContent("登录初始化失败，请重新登录或检查网络连接")
-                    .Queue());
+                toastManager.ShowDismissibleToast(NotificationType.Error, "登录初始化失败", "登录初始化失败，请重新登录或检查网络连接"));
             loginClient.LogOutAsync();
             return LoginInitializationResult.FailedResult;
         }

--- a/src/Apps/KugouAvaloniaPlayer/Services/PersonalFmService.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/PersonalFmService.cs
@@ -324,6 +324,7 @@ public sealed class PersonalFmService(
             Hash = song.Hash,
             AlbumId = song.AlbumId,
             AudioId = song.AudioId,
+            AlbumAudioId = long.TryParse(song.MixSongId, out var mixId) ? mixId : 0,
             Singers = song.Singers,
             Cover = ResolvePersonalFmCover(song),
             DurationSeconds = song.DurationSeconds,

--- a/src/Apps/KugouAvaloniaPlayer/Services/SukiToastExtensions.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Services/SukiToastExtensions.cs
@@ -1,0 +1,67 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
+using Avalonia.Layout;
+using SukiUI.Toasts;
+
+namespace KugouAvaloniaPlayer.Services;
+
+/// <summary>
+///     Toast 统一构建扩展：内容区带可点击的关闭按钮（小 ✕），
+///     点击 ✕ 立即关闭，无需等待倒计时结束。
+/// </summary>
+public static class SukiToastExtensions
+{
+    public static void ShowDismissibleToast(
+        this ISukiToastManager manager,
+        NotificationType type,
+        string title,
+        string content,
+        TimeSpan? dismissAfter = null)
+    {
+        // 闭包捕获 toast 引用：Queue() 返回 ISukiToast 后回填给关闭按钮的 Click 处理器
+        ISukiToast? toastRef = null;
+
+        var closeButton = new Button
+        {
+            Content = "✕",
+            Padding = new Avalonia.Thickness(4, 0),
+            Margin = new Avalonia.Thickness(8, -2, -4, 0),
+            VerticalAlignment = VerticalAlignment.Top,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Background = Avalonia.Media.Brushes.Transparent,
+            BorderThickness = new Avalonia.Thickness(0),
+            FontSize = 13,
+            Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand)
+        };
+        closeButton.Click += (_, _) =>
+        {
+            if (toastRef is { } toast)
+                manager.Dismiss(toast, SukiToastDismissSource.Code);
+        };
+
+        var text = new TextBlock
+        {
+            Text = content,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto")
+        };
+        Grid.SetColumn(text, 0);
+        Grid.SetColumn(closeButton, 1);
+        grid.Children.Add(text);
+        grid.Children.Add(closeButton);
+
+        toastRef = manager.CreateToast()
+            .OfType(type)
+            .WithTitle(title)
+            .WithContent(grid)
+            .Dismiss()
+            .After(dismissAfter ?? TimeSpan.FromSeconds(4))
+            .Queue();
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/ViewLocator.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewLocator.cs
@@ -19,6 +19,7 @@ public class ViewLocator : IDataTemplate
             [typeof(SearchViewModel)] = static () => new SearchView(),
             [typeof(UserCloudViewModel)] = static () => new UserCloudView(),
             [typeof(SingerViewModel)] = static () => new SingerView(),
+            [typeof(SimilarSongsViewModel)] = static () => new SimilarSongsView(),
             [typeof(SettingViewModel)] = static () => new SettingView(),
             [typeof(RankViewModel)] = static () => new RankView(),
             [typeof(DailyRecommendViewModel)] = static () => new DailyRecommendView(),

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/DailyRecommendViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/DailyRecommendViewModel.cs
@@ -101,10 +101,25 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
             _songInteractions.NavigateToSinger(singer);
     }
 
+    [RelayCommand]
+    private void ShowSimilarSongs(SongItem? song)
+    {
+        if (song != null)
+            _songInteractions.NavigateToSimilarSongs(song);
+    }
+
+    [RelayCommand]
+    private void SearchSong(SongItem? song)
+    {
+        if (song != null)
+            _songInteractions.SearchSong(song, KugouAvaloniaPlayer.Models.SearchType.Playlist);
+    }
+
     public PersonalFmSongPoolOption[] FmSongPoolOptions { get; } =
     [
         new(PersonalFmSongPoolId.Taste, "根据口味"),
-        new(PersonalFmSongPoolId.Style, "根据风格")
+        new(PersonalFmSongPoolId.Style, "根据风格"),
+        new(PersonalFmSongPoolId.Special, "特殊推荐池")
     ];
 
     public bool CanUsePersonalFm => !string.IsNullOrWhiteSpace(_sessionManager.Session.Token) &&
@@ -120,7 +135,12 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
     public bool IsFmPlaying => IsFmActive && _player.IsPlayingAudio;
     public string FmCardTitle => PersonalFmPresentation.GetTitle(SelectedFmMode);
     public string FmModeShortLabel => PersonalFmPresentation.GetModeLabel(SelectedFmMode);
-    public string FmSongPoolButtonText => SelectedFmSongPoolId == PersonalFmSongPoolId.Style ? "风格" : "口味";
+    public string FmSongPoolButtonText => SelectedFmSongPoolId switch
+    {
+        PersonalFmSongPoolId.Style => "风格",
+        PersonalFmSongPoolId.Special => "特殊",
+        _ => "口味"
+    };
     public string FmCardTagline => $"{PersonalFmPresentation.GetModeLabel(SelectedFmMode)} · {PersonalFmPresentation.GetSongPoolLabel(SelectedFmSongPoolId)}";
 
     public string FmCardSubtitle
@@ -268,9 +288,12 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
         if (IsFmLoading)
             return;
 
-        SelectedFmSongPoolId = SelectedFmSongPoolId == PersonalFmSongPoolId.Taste
-            ? PersonalFmSongPoolId.Style
-            : PersonalFmSongPoolId.Taste;
+        SelectedFmSongPoolId = SelectedFmSongPoolId switch
+        {
+            PersonalFmSongPoolId.Taste => PersonalFmSongPoolId.Style,
+            PersonalFmSongPoolId.Style => PersonalFmSongPoolId.Special,
+            _ => PersonalFmSongPoolId.Taste
+        };
 
         await LoadPersonalFmPreviewAsync(IsFmActive, true);
     }
@@ -335,6 +358,22 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
         await LoadPersonalFmPreviewAsync(IsFmActive, true);
     }
 
+    [RelayCommand(CanExecute = nameof(CanRefreshDailyRecommendations))]
+    private async Task RefreshDailyRecommendations()
+    {
+        if (IsDailyRecommendationsLoading)
+            return;
+
+        await LoadDailyRecommendationsAsync();
+    }
+
+    private bool CanRefreshDailyRecommendations() => !IsDailyRecommendationsLoading;
+
+    partial void OnIsDailyRecommendationsLoadingChanged(bool value)
+    {
+        RefreshDailyRecommendationsCommand.NotifyCanExecuteChanged();
+    }
+
     private async Task LoadDailyRecommendationsAsync()
     {
         _logger.LogInformation("正在获取每日推荐...");
@@ -354,6 +393,7 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
                     AlbumId = item.AlbumId,
                     AlbumName = item.AlbumName,
                     AudioId = item.AudioId,
+                    AlbumAudioId = item.MixSongId,
                     Singers = item.Singers,
                     Cover = string.IsNullOrWhiteSpace(item.SizableCover) ? DefaultCover : item.SizableCover,
                     DurationSeconds = item.Duration
@@ -560,12 +600,7 @@ public partial class DailyRecommendViewModel : PageViewModelBase, IDisposable
     {
         Dispatcher.UIThread.Post(() =>
         {
-            _toastManager.CreateToast()
-                .OfType(type)
-                .WithTitle(title)
-                .WithContent(content)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            _toastManager.ShowDismissibleToast(type, title, content);
         });
     }
 

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/DiscoverTagViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/DiscoverTagViewModel.cs
@@ -305,24 +305,12 @@ public partial class DiscoverTagViewModel : PageViewModelBase
             if (result != null)
             {
                 _messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("收藏成功")
-                    .WithContent($"已将「{SelectedPlaylist.Name}」收藏到我的歌单")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "收藏成功", $"已将「{SelectedPlaylist.Name}」收藏到我的歌单");
             }
         }
         catch (Exception ex)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("收藏失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "收藏失败", ex.Message);
         }
     }
 
@@ -375,6 +363,7 @@ public partial class DiscoverTagViewModel : PageViewModelBase
                 Hash = s.Hash,
                 AlbumId = s.AlbumId,
                 AlbumName = s.Album?.Name ?? "",
+                AlbumAudioId = s.MixSongId,
                 FileId = s.FileId,
                 Singers = s.Singers,
                 Cover = string.IsNullOrWhiteSpace(s.Cover) ? DefaultSongCover : s.Cover,
@@ -409,12 +398,11 @@ public partial class DiscoverTagViewModel : PageViewModelBase
 
     private void ShowWarning(string title, string content)
     {
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Warning)
-            .WithTitle(title)
-            .WithContent(content)
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Warning, title, content);
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/DiscoverViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/DiscoverViewModel.cs
@@ -302,24 +302,12 @@ public partial class DiscoverViewModel : PageViewModelBase
             if (result != null)
             {
                 _messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("收藏成功")
-                    .WithContent($"已将「{SelectedPlaylist.Name}」收藏到我的歌单")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "收藏成功", $"已将「{SelectedPlaylist.Name}」收藏到我的歌单");
             }
         }
         catch (Exception ex)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("收藏失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "收藏失败", ex.Message);
         }
     }
 
@@ -495,6 +483,7 @@ public partial class DiscoverViewModel : PageViewModelBase
                 Hash = s.Hash,
                 AlbumId = s.AlbumId,
                 AlbumName = s.Album?.Name ?? "",
+                AlbumAudioId = s.MixSongId,
                 FileId = s.FileId,
                 Singers = s.Singers,
                 Cover = string.IsNullOrWhiteSpace(s.Cover) ? DefaultSongCover : s.Cover,
@@ -618,13 +607,12 @@ public partial class DiscoverViewModel : PageViewModelBase
 
     private void ShowWarning(string title, string content)
     {
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Warning)
-            .WithTitle(title)
-            .WithContent(content)
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Warning, title, content);
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 
     private readonly record struct DiscoverTopCardDefinition(int CardId, string Title);

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/LocalMusicLibraryViewModel.cs
@@ -188,13 +188,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
 
     private void ShowSearchNavigationError(string message)
     {
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Warning)
-            .WithTitle("无法打开搜索结果")
-            .WithContent(message)
-            .Dismiss().After(TimeSpan.FromSeconds(4))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Warning, "无法打开搜索结果", message);
     }
 
     [RelayCommand]
@@ -210,13 +204,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "加载本地音乐库失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("本地音乐库加载失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "本地音乐库加载失败", ex.Message);
         }
     }
 
@@ -252,13 +240,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "加载本地歌单歌曲失败 playlistId={PlaylistId}", item.Id);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("加载失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "加载失败", ex.Message);
         }
         finally
         {
@@ -288,24 +270,12 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
                 IsShowingSongs = false;
             }
 
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("已删除")
-                .WithContent($"已删除本地歌单「{item.Name}」")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "已删除", $"已删除本地歌单「{item.Name}」");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "删除本地歌单失败 playlistId={PlaylistId}", item.Id);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("删除失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "删除失败", ex.Message);
         }
     }
 
@@ -326,13 +296,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         item.Cover = GetImageSourceOrDefault(result.CoverPath, DefaultCover);
         item.Subtitle = $"{item.Count} 首歌曲";
 
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Success)
-            .WithTitle("已保存")
-            .WithContent($"已更新本地歌单「{item.Name}」")
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Success, "已保存", $"已更新本地歌单「{item.Name}」");
     }
 
     [RelayCommand]
@@ -349,13 +313,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
         if (!string.IsNullOrWhiteSpace(song.LocalFilePath))
             song.Cover = LocalImageSourceHelper.BuildEmbeddedCoverSource(song.LocalFilePath);
 
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Success)
-            .WithTitle("已设置封面")
-            .WithContent($"已将封面写入「{song.Name}」的音频标签")
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-                .Queue();
+        ShowToast(NotificationType.Success, "已设置封面", $"已将封面写入「{song.Name}」的音频标签");
     }
 
     [RelayCommand]
@@ -382,13 +340,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             sidebarItem.Subtitle = SelectedPlaylist.Subtitle;
         }
 
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Success)
-            .WithTitle("移除成功")
-            .WithContent($"已从歌单移除「{song.Name}」")
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Success, "移除成功", $"已从歌单移除「{song.Name}」");
     }
 
     [RelayCommand]
@@ -406,24 +358,12 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             if (item != null)
                 await OpenPlaylist(item);
 
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("创建成功")
-                .WithContent($"已创建本地歌单「{playlist.Name}」")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "创建成功", $"已创建本地歌单「{playlist.Name}」");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "创建本地歌单失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("创建失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "创建失败", ex.Message);
         }
     }
 
@@ -455,24 +395,12 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             if (target != null)
                 await OpenPlaylist(target);
 
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("已添加")
-                .WithContent($"已添加 {files.Count} 首本地歌曲。")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "已添加", $"已添加 {files.Count} 首本地歌曲。");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "添加本地歌曲失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("添加失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "添加失败", ex.Message);
         }
     }
 
@@ -501,24 +429,12 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             if (item != null)
                 await OpenPlaylist(item);
 
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("导入完成")
-                .WithContent($"已导入本地歌单「{imported.Name}」，共 {imported.TrackCount} 首。")
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "导入完成", $"已导入本地歌单「{imported.Name}」，共 {imported.TrackCount} 首。");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "导入本地文件夹失败 path={Path}", path);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("导入失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "导入失败", ex.Message);
         }
         finally
         {
@@ -550,26 +466,14 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             }
 
             var songCount = refreshed.AsValueEnumerable().Sum(x => x.TrackCount);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("刷新完成")
-                .WithContent(refreshed.Count == 0
-                    ? "没有可刷新的导入音乐库。"
-                    : $"已刷新 {refreshed.Count} 个歌单，共 {songCount} 首。")
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "刷新完成", refreshed.Count == 0
+                ? "没有可刷新的导入音乐库。"
+                : $"已刷新 {refreshed.Count} 个歌单，共 {songCount} 首。");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "刷新本地音乐库失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("刷新失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "刷新失败", ex.Message);
         }
         finally
         {
@@ -595,13 +499,7 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             var libraries = await _jellyfinClient.GetMusicLibrariesAsync(options);
             if (libraries.Count == 0)
             {
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Warning)
-                    .WithTitle("未找到音乐库")
-                    .WithContent("当前 Jellyfin 用户没有可导入的音乐媒体库。")
-                    .Dismiss().After(TimeSpan.FromSeconds(4))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Warning, "未找到音乐库", "当前 Jellyfin 用户没有可导入的音乐媒体库。");
                 return;
             }
 
@@ -658,24 +556,12 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
                 await OpenPlaylist(item);
 
             var importedSongCount = imported.AsValueEnumerable().Sum(x => x.TrackCount);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("导入完成")
-                .WithContent($"已按专辑同步 Jellyfin 媒体库「{library.Name}」，生成 {imported.Count} 个本地歌单，共 {importedSongCount} 首。")
-                .Dismiss().After(TimeSpan.FromSeconds(5))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "导入完成", $"已按专辑同步 Jellyfin 媒体库「{library.Name}」，生成 {imported.Count} 个本地歌单，共 {importedSongCount} 首。");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "导入 Jellyfin 媒体库失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("导入失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(5))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "导入失败", ex.Message);
         }
         finally
         {
@@ -819,5 +705,10 @@ public partial class LocalMusicLibraryViewModel : PageViewModelBase
             return null;
 
         return uri.LocalPath;
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/MainWindowViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/MainWindowViewModel.cs
@@ -170,6 +170,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 OnLogoutRequested();
         });
 
+        _messenger.Register<SearchRequestedEvent>(this, (_, m) =>
+        {
+            _ = OnSearchRequestedAsync(m.Keyword, m.Type);
+        });
+
         _ = InitializeStartupAsync();
 
         _ = ApplyDeferredStartupPreferencesAsync();
@@ -512,12 +517,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             return;
 
         await Dispatcher.UIThread.InvokeAsync(() =>
-            ToastManager.CreateToast()
-                .OfType(NotificationType.Warning)
-                .WithTitle(toastContent.Item1)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .WithContent(toastContent.Item2)
-                .Queue());
+            ShowToast(NotificationType.Warning, toastContent.Item1, toastContent.Item2));
     }
 
     private void ApplyUserProfile(UserProfileSnapshot? profile)
@@ -534,12 +534,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private void ShowLoadUserInfoFailedToast()
     {
-        ToastManager.CreateToast()
-            .OfType(NotificationType.Warning)
-            .WithTitle("加载用户失败")
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Dismiss().ByClicking()
-            .Queue();
+        ShowToast(NotificationType.Warning, "加载用户失败");
     }
 
     private void OnLogoutRequested()
@@ -633,6 +628,19 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         _navigationService.NavigateTransient(_searchViewModel);
         await _searchViewModel.SearchAsync(SearchKeyword);
+    }
+
+    private async Task OnSearchRequestedAsync(string keyword, SearchType? type)
+    {
+        if (string.IsNullOrWhiteSpace(keyword))
+            return;
+
+        if (type.HasValue)
+            _searchViewModel.CurrentSearchType = type.Value;
+
+        SearchKeyword = keyword;
+        _navigationService.NavigateTransient(_searchViewModel);
+        await _searchViewModel.SearchAsync(keyword);
     }
 
     private bool CanSearch()
@@ -748,6 +756,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             preferences.UseCustomImage,
             preferences.CustomImagePath,
             preferences.CustomImageOpacity);
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        ToastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 
     public void Dispose()

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/MyPlaylistsViewModel.cs
@@ -408,6 +408,7 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
             Hash = s.Hash,
             AlbumId = s.AlbumId,
             AlbumName = s.Album?.Name ?? "",
+            AlbumAudioId = s.MixSongId,
             FileId = s.FileId,
             Singers = s.Singers,
             Cover = string.IsNullOrWhiteSpace(s.Cover) ? DefaultSongCover : s.Cover,
@@ -550,13 +551,7 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
             var parseResult = await _externalPlaylistImportService.ParseAndLoadAsync(link);
             if (!parseResult.Success)
             {
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Error)
-                    .WithTitle("解析失败")
-                    .WithContent(parseResult.ErrorMessage)
-                    .Dismiss().After(TimeSpan.FromSeconds(4))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Error, "解析失败", parseResult.ErrorMessage);
                 return;
             }
 
@@ -604,13 +599,7 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
 
             if (!importResult.Success)
             {
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Error)
-                    .WithTitle("导入失败")
-                    .WithContent(importResult.ErrorMessage)
-                    .Dismiss().After(TimeSpan.FromSeconds(4))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Error, "导入失败", importResult.ErrorMessage);
                 return;
             }
 
@@ -624,24 +613,12 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
             else if (importResult.Matched == 0)
                 summary += "\n未匹配到可导入歌曲。";
 
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("导入完成")
-                .WithContent(summary)
-                .Dismiss().After(TimeSpan.FromSeconds(6))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "导入完成", summary);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "导入其他平台歌单时发生异常");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("导入失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(4))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "导入失败", ex.Message);
         }
         finally
         {
@@ -660,24 +637,12 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
             if (result != null)
             {
                 _messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("创建成功")
-                    .WithContent($"已创建歌单「{name}」")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "创建成功", $"已创建歌单「{name}」");
             }
         }
         catch (Exception ex)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("创建失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "创建失败", ex.Message);
         }
     }
 
@@ -709,25 +674,13 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
                     ? $"已取消收藏专辑「{item.Name}」"
                     : $"已删除歌单「{item.Name}」";
 
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle(successTitle)
-                    .WithContent(successContent)
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, successTitle, successContent);
             }
         }
         catch (Exception ex)
         {
             var failTitle = item.Type == PlaylistType.Album ? "取消收藏失败" : "删除失败";
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle(failTitle)
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, failTitle, ex.Message);
         }
     }
 
@@ -794,24 +747,12 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
                 if (SelectedPlaylist.Count > 0)
                     SelectedPlaylist.Count--;
 
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("移除成功")
-                    .WithContent($"已从歌单移除「{song.Name}」")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "移除成功", $"已从歌单移除「{song.Name}」");
             }
         }
         catch (Exception ex)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("移除失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "移除失败", ex.Message);
         }
     }
 
@@ -910,6 +851,11 @@ public partial class MyPlaylistsViewModel : PageViewModelBase, IDisposable
             PlaylistSongSortMode.Album => AlbumSortText,
             _ => DefaultSortText
         };
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 
     public void Dispose()

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/NowPlayingViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/NowPlayingViewModel.cs
@@ -70,6 +70,16 @@ public partial class NowPlayingViewModel : ViewModelBase, IDisposable
     public MouseParallaxTuningViewModel PendoloParallaxTuning { get; }
     public MouseParallaxTuningViewModel FumeParallaxTuning { get; }
 
+    [RelayCommand]
+    private void ShowSimilarSongs()
+    {
+        var song = Player.DisplayedPlayingSong;
+        if (song is null)
+            return;
+
+        _songInteractionService.NavigateToSimilarSongs(song);
+    }
+
     public IReadOnlyList<NowPlayingThemePresetOption> ThemePresets =>
         NowPlayingThemePresetRegistry.Presets;
 

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.PersonalFm.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.PersonalFm.cs
@@ -152,12 +152,7 @@ public partial class PlayerViewModel
     {
         Dispatcher.UIThread.Post(() =>
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Warning)
-                .WithTitle("私人 FM")
-                .WithContent(content)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            ShowToast(NotificationType.Warning, "私人 FM", content);
         });
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.Queue.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.Queue.cs
@@ -49,11 +49,7 @@ public partial class PlayerViewModel
     {
         if (songs.Count == 0)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Warning)
-                .WithTitle("没有可添加的歌曲")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            ShowToast(NotificationType.Warning, "没有可添加的歌曲");
             return;
         }
 
@@ -61,12 +57,7 @@ public partial class PlayerViewModel
             ClearPersonalFmSession();
 
         _queueManager.AddToEnd(songs);
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Success)
-            .WithTitle("已添加到播放列表")
-            .WithContent($"已添加 {songs.Count} 首歌曲")
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .Queue();
+        ShowToast(NotificationType.Success, "已添加到播放列表", $"已添加 {songs.Count} 首歌曲");
     }
 
     void IPlaybackCommands.AddToQueue(IReadOnlyList<SongItem> songs)
@@ -87,11 +78,7 @@ public partial class PlayerViewModel
     {
         if (songs.Count == 0)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Warning)
-                .WithTitle("没有可播放的歌曲")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            ShowToast(NotificationType.Warning, "没有可播放的歌曲");
             return;
         }
 
@@ -447,5 +434,10 @@ public partial class PlayerViewModel
         }
 
         Dispatcher.UIThread.Post(() => _ = PlayNext());
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.State.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.State.cs
@@ -325,12 +325,7 @@ public partial class PlayerViewModel
             {
                 currentLoadCts.Dispose();
                 RevertQualitySelectionToCurrentQuality();
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Warning)
-                    .WithTitle("切换音质失败")
-                    .WithContent(GetQualitySwitchFailureMessage(sourceInfo.FailureReason))
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Queue();
+                ShowToast(NotificationType.Warning, "切换音质失败", GetQualitySwitchFailureMessage(sourceInfo.FailureReason));
                 return false;
             }
 
@@ -358,12 +353,7 @@ public partial class PlayerViewModel
             if (!loadSuccess)
             {
                 RevertQualitySelectionToCurrentQuality();
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Warning)
-                    .WithTitle("切换音质失败")
-                    .WithContent("新的音频流加载失败。")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Queue();
+                ShowToast(NotificationType.Warning, "切换音质失败", "新的音频流加载失败。");
                 return false;
             }
 
@@ -395,12 +385,7 @@ public partial class PlayerViewModel
         {
             RevertQualitySelectionToCurrentQuality();
             _logger.LogError(ex, "切换音质失败");
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("切换音质失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            ShowToast(NotificationType.Error, "切换音质失败", ex.Message);
             return false;
         }
         finally

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/PlayerViewModel.cs
@@ -283,12 +283,7 @@ public partial class PlayerViewModel : ViewModelBase, IPlaybackCommands, IDispos
         {
             if (_consecutiveFailures >= MaxConsecutiveFailures)
             {
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Error)
-                    .WithTitle("熔断保护")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .WithContent("连续多次失败，停止播放，建议重新登录")
-                    .Queue();
+                ShowToast(NotificationType.Error, "熔断保护", "连续多次失败，停止播放，建议重新登录");
                 _consecutiveFailures = 0;
                 return;
             }
@@ -442,12 +437,7 @@ public partial class PlayerViewModel : ViewModelBase, IPlaybackCommands, IDispos
             MaxConsecutiveFailures,
             song.Name,
             detail);
-        _toastManager.CreateToast()
-            .OfType(NotificationType.Warning)
-            .WithTitle(failureStage)
-            .Dismiss().After(TimeSpan.FromSeconds(3))
-            .WithContent($"{song.Name}")
-            .Queue();
+        ShowToast(NotificationType.Warning, failureStage, $"{song.Name}");
         Dispatcher.UIThread.Post(() =>
         {
             var currentIndex = PlaybackQueue.IndexOf(song);
@@ -463,12 +453,7 @@ public partial class PlayerViewModel : ViewModelBase, IPlaybackCommands, IDispos
             else
             {
                 StopAndReset();
-                _toastManager.CreateToast()
-                    .OfType(NotificationType.Warning)
-                    .WithTitle("播放失败")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .WithContent("队列中没有可播放的歌曲")
-                    .Queue();
+                ShowToast(NotificationType.Warning, "播放失败", "队列中没有可播放的歌曲");
             }
         });
     }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/RankViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/RankViewModel.cs
@@ -160,12 +160,7 @@ public partial class RankViewModel : PageViewModelBase
         }
         catch (Exception ex)
         {
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Warning)
-                .WithTitle("获取排行榜失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Queue();
+            ShowToast(NotificationType.Warning, "获取排行榜失败", ex.Message);
         }
     }
 
@@ -250,6 +245,7 @@ public partial class RankViewModel : PageViewModelBase
                     Hash = s.Hash,
                     AlbumId = s.AlbumId.ToString(),
                     AlbumName = s.Album?.Name ?? "",
+                    AlbumAudioId = s.AlbumAudioId,
                     Singers = s.Singers,
                     Cover =
                         string.IsNullOrWhiteSpace(s.TransParam?.UnionCover) ? DefaultCover : s.TransParam.UnionCover,
@@ -300,5 +296,10 @@ public partial class RankViewModel : PageViewModelBase
             5 => "曲风榜",
             _ => "其他榜单"
         };
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SearchViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SearchViewModel.cs
@@ -104,6 +104,20 @@ public partial class SearchViewModel(
             songInteractions.NavigateToSinger(singer);
     }
 
+    [RelayCommand]
+    private void ShowSimilarSongs(SongItem? song)
+    {
+        if (song != null)
+            songInteractions.NavigateToSimilarSongs(song);
+    }
+
+    [RelayCommand]
+    private void SearchSong(SongItem? song)
+    {
+        if (song != null)
+            songInteractions.SearchSong(song, SearchType.Playlist);
+    }
+
     // 当前是否显示歌单详情（用于控制收藏按钮可见性）
     public bool IsPlaylistDetail => _currentDetailType == DetailType.Playlist;
     public bool IsAlbumDetail => _currentDetailType == DetailType.Album;
@@ -376,6 +390,7 @@ public partial class SearchViewModel(
                         Hash = s.Hash,
                         AlbumId = s.AlbumId,
                         AlbumName = s.Album?.Name ?? "",
+                        AlbumAudioId = s.MixSongId,
                         Singers = s.Singers,
                         Cover = string.IsNullOrWhiteSpace(s.Cover) ? DefaultSongCover : s.Cover,
                         DurationSeconds = s.DurationMs / 1000.0
@@ -462,6 +477,7 @@ public partial class SearchViewModel(
             Hash = item.Hash,
             AlbumId = item.AlbumId,
             AlbumName = item.AlbumName,
+            AlbumAudioId = item.AlbumAudioId,
             Singers = item.Singers,
             Cover = string.IsNullOrWhiteSpace(item.Cover) ? DefaultSongCover : item.Cover,
             DurationSeconds = item.Duration
@@ -492,25 +508,13 @@ public partial class SearchViewModel(
             if (result != null)
             {
                 messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-                toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("收藏成功")
-                    .WithContent($"已将「{_currentPlaylistName}」收藏到我的歌单")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "收藏成功", $"已将「{_currentPlaylistName}」收藏到我的歌单");
             }
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "收藏歌单失败");
-            toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("收藏失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "收藏失败", ex.Message);
         }
     }
 
@@ -529,25 +533,18 @@ public partial class SearchViewModel(
             if (result != null)
             {
                 messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-                toastManager.CreateToast()
-                    .OfType(NotificationType.Success)
-                    .WithTitle("收藏成功")
-                    .WithContent($"已将专辑「{DetailTitle}」收藏到我的歌单")
-                    .Dismiss().After(TimeSpan.FromSeconds(3))
-                    .Dismiss().ByClicking()
-                    .Queue();
+                ShowToast(NotificationType.Success, "收藏成功", $"已将专辑「{DetailTitle}」收藏到我的歌单");
             }
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "收藏专辑失败");
-            toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("收藏失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "收藏失败", ex.Message);
         }
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SimilarSongsViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SimilarSongsViewModel.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using ZLinq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Collections;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using KuGou.Net.Abstractions.Models;
+using KuGou.Net.Clients;
+using KugouAvaloniaPlayer.Services;
+using Microsoft.Extensions.Logging;
+using SukiUI.Toasts;
+
+namespace KugouAvaloniaPlayer.ViewModels;
+
+public partial class SimilarSongsViewModel : PageViewModelBase, IDisposable
+{
+    private const string DefaultCover = "avares://KugouAvaloniaPlayer/Assets/default_song.png";
+
+    private readonly RecommendClient _recommendClient;
+    private readonly ISukiToastManager _toastManager;
+    private readonly ILogger<SimilarSongsViewModel> _logger;
+    private readonly SongItem _sourceSong;
+
+    private bool _isDisposed;
+    private int _requestVersion;
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsLoadingMore { get; set; }
+
+    [ObservableProperty]
+    public partial string SourceCover { get; set; }
+
+    [ObservableProperty]
+    public partial string Title { get; set; }
+
+    public AvaloniaList<SongItem> Songs { get; } = new();
+
+    public SimilarSongsViewModel(
+        RecommendClient recommendClient,
+        ISukiToastManager toastManager,
+        ILogger<SimilarSongsViewModel> logger,
+        SongItem sourceSong)
+    {
+        _recommendClient = recommendClient;
+        _toastManager = toastManager;
+        _logger = logger;
+        _sourceSong = sourceSong;
+
+        SourceCover = string.IsNullOrWhiteSpace(sourceSong.Cover) ? DefaultCover : sourceSong.Cover;
+        Title = $"{sourceSong.Name} 的相似推荐";
+
+        _ = LoadAsync();
+    }
+
+    public override string DisplayName => "相似歌曲";
+    public override string Icon => DefaultCover;
+
+    private async Task LoadAsync()
+    {
+        if (_isDisposed)
+            return;
+
+        if (_sourceSong.AlbumAudioId == 0)
+        {
+            ShowToast("相似歌曲", "当前歌曲缺少在线信息，无法推荐", Avalonia.Controls.Notifications.NotificationType.Warning);
+            return;
+        }
+
+        var requestVersion = Interlocked.Increment(ref _requestVersion);
+        IsLoading = true;
+
+        try
+        {
+            var json = await _recommendClient.GetAiRecommendAsync(_sourceSong.AlbumAudioId.ToString());
+            if (!IsCurrentRequest(requestVersion))
+                return;
+
+            var songs = ParseSimilarSongs(json);
+            if (!IsCurrentRequest(requestVersion))
+                return;
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                Songs.Clear();
+                Songs.AddRange(songs);
+            });
+
+            if (songs.Count == 0)
+                ShowToast("相似歌曲", "暂时没有相似的推荐", Avalonia.Controls.Notifications.NotificationType.Information);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "加载相似歌曲失败");
+            ShowToast("相似歌曲", "加载相似歌曲失败，请稍后再试", Avalonia.Controls.Notifications.NotificationType.Error);
+        }
+        finally
+        {
+            if (IsCurrentRequest(requestVersion))
+                IsLoading = false;
+        }
+    }
+
+    /// <summary>
+    ///     容错解析 AI 相似推荐响应。返回结构尚未校准，按多个候选 key 定位歌曲数组与字段。
+    ///     实跑对照日志后可收紧为固定模型反序列化。
+    /// </summary>
+    private List<SongItem> ParseSimilarSongs(JsonElement root)
+    {
+        var result = new List<SongItem>();
+
+        // 1. 提取 data 节点（酷狗常见外层包裹）
+        var dataElement = root;
+        if (root.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object)
+            dataElement = data;
+
+        // 2. 在 data / root 里找歌曲数组（候选 key）
+        var songsArray = FindSongsArray(dataElement) ?? FindSongsArray(root);
+        if (songsArray is null || songsArray.Value.ValueKind != JsonValueKind.Array)
+        {
+            _logger.LogWarning("相似推荐响应中未找到歌曲数组，候选 key 均不匹配");
+            return result;
+        }
+
+        foreach (var item in songsArray.Value.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var hash = GetString(item, "hash", "filename_hash");
+            if (string.IsNullOrWhiteSpace(hash))
+                continue;
+
+            var song = new SongItem
+            {
+                Name = GetString(item, "songname", "name", "song_name", "filename") ?? "",
+                Singer = GetString(item, "author_name", "singername", "singer_name", "author") ?? "",
+                Hash = hash,
+                AlbumId = GetString(item, "album_id", "albumid") ?? "",
+                AlbumName = GetString(item, "album_name", "albumname") ?? "",
+                Cover = GetCover(item),
+                DurationSeconds = GetInt(item, "time_length", "duration", "timelength"),
+                AudioId = GetLong(item, "songid", "audio_id", "song_id"),
+                AlbumAudioId = GetLong(item, "mixsongid", "album_audio_id", "mix_song_id")
+            };
+
+            result.Add(song);
+        }
+
+        return result;
+    }
+
+    private static JsonElement? FindSongsArray(JsonElement obj)
+    {
+        if (obj.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var candidates = new[] { "song_list", "songs", "list", "playlist", "audios", "songList", "data" };
+        foreach (var key in candidates)
+        {
+            if (obj.TryGetProperty(key, out var prop) && prop.ValueKind == JsonValueKind.Array)
+                return prop;
+        }
+
+        return null;
+    }
+
+    private static string? GetString(JsonElement obj, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (obj.TryGetProperty(key, out var prop) && prop.ValueKind == JsonValueKind.String)
+            {
+                var v = prop.GetString();
+                if (!string.IsNullOrWhiteSpace(v))
+                    return v;
+            }
+        }
+        return null;
+    }
+
+    private static int GetInt(JsonElement obj, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (obj.TryGetProperty(key, out var prop) && prop.ValueKind == JsonValueKind.Number)
+            {
+                if (prop.TryGetInt32(out var i))
+                    return i;
+            }
+        }
+        return 0;
+    }
+
+    private static long GetLong(JsonElement obj, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!obj.TryGetProperty(key, out var prop))
+                continue;
+
+            if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt64(out var l))
+                return l;
+
+            // 酷狗常把 id 以字符串返回，如 mixsongid: "288598536"
+            if (prop.ValueKind == JsonValueKind.String &&
+                long.TryParse(prop.GetString(), out var sl))
+                return sl;
+        }
+        return 0;
+    }
+
+    private static string GetCover(JsonElement obj)
+    {
+        var cover = GetString(obj, "sizable_cover", "cover", "cover_img_url", "img");
+        if (string.IsNullOrWhiteSpace(cover) && obj.TryGetProperty("trans_param", out var trans) &&
+            trans.ValueKind == JsonValueKind.Object)
+        {
+            cover = GetString(trans, "union_cover", "cover");
+        }
+
+        if (string.IsNullOrWhiteSpace(cover))
+            return DefaultCover;
+        return cover.Replace("{size}", "400");
+    }
+
+    private bool IsCurrentRequest(int requestVersion) =>
+        !_isDisposed && requestVersion == _requestVersion;
+
+    private void ShowToast(string title, string content, Avalonia.Controls.Notifications.NotificationType type)
+    {
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            _toastManager.ShowDismissibleToast(type, title, content);
+        });
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        Interlocked.Increment(ref _requestVersion);
+        Songs.Clear();
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/SingerViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/SingerViewModel.cs
@@ -242,6 +242,7 @@ public partial class SingerViewModel : PageViewModelBase, IDisposable
                     Hash = item.Hash,
                     AlbumId = item.AlbumId.ToString(),
                     AlbumName = item.AlbumName,
+                    AlbumAudioId = item.AlbumAudioId,
                     DurationSeconds = item.Duration / 1000.0,
                     Cover = item.TransParam?.UnionCover
                 })
@@ -498,13 +499,7 @@ public partial class SingerViewModel : PageViewModelBase, IDisposable
                 return;
 
             _messenger.Send(new PlaylistCollectionChangedEvent(PlaylistChangeKind.Created));
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Success)
-                .WithTitle("收藏成功")
-                .WithContent($"已将专辑「{AlbumDetailTitle}」收藏到我的歌单")
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Success, "收藏成功", $"已将专辑「{AlbumDetailTitle}」收藏到我的歌单");
         }
         catch (Exception ex)
         {
@@ -512,13 +507,7 @@ public partial class SingerViewModel : PageViewModelBase, IDisposable
                 return;
 
             _logger.LogError(ex, "收藏歌手专辑失败，albumId={AlbumId}", _currentAlbumId);
-            _toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("收藏失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "收藏失败", ex.Message);
         }
     }
 
@@ -580,6 +569,11 @@ public partial class SingerViewModel : PageViewModelBase, IDisposable
         Songs.Clear();
         Albums.Clear();
         AlbumSongs.Clear();
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        _toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }
 

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/UserCloudViewModel.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/UserCloudViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using KuGou.Net.Abstractions.Models;
 using KuGou.Net.Clients;
 using KugouAvaloniaPlayer.Models;
+using KugouAvaloniaPlayer.Services;
 using Microsoft.Extensions.Logging;
 using SukiUI.Toasts;
 using ZLinq;
@@ -83,13 +84,7 @@ public partial class UserCloudViewModel(
         catch (Exception ex)
         {
             logger.LogError(ex, "加载云盘歌曲失败");
-            toastManager.CreateToast()
-                .OfType(NotificationType.Error)
-                .WithTitle("加载云盘失败")
-                .WithContent(ex.Message)
-                .Dismiss().After(TimeSpan.FromSeconds(3))
-                .Dismiss().ByClicking()
-                .Queue();
+            ShowToast(NotificationType.Error, "加载云盘失败", ex.Message);
         }
         finally
         {
@@ -293,5 +288,10 @@ public partial class UserCloudViewModel(
 
         var format = unitIndex == 0 ? "0" : "0.##";
         return value.ToString(format, CultureInfo.InvariantCulture) + " " + units[unitIndex];
+    }
+
+    private void ShowToast(NotificationType type, string title, string? content = null)
+    {
+        toastManager.ShowDismissibleToast(type, title, content ?? string.Empty);
     }
 }

--- a/src/Apps/KugouAvaloniaPlayer/ViewModels/ViewModelFactories.cs
+++ b/src/Apps/KugouAvaloniaPlayer/ViewModels/ViewModelFactories.cs
@@ -35,6 +35,23 @@ public sealed class SingerViewModelFactory(
     }
 }
 
+public interface ISimilarSongsViewModelFactory
+{
+    SimilarSongsViewModel Create(SongItem sourceSong);
+}
+
+public sealed class SimilarSongsViewModelFactory(
+    RecommendClient recommendClient,
+    ISukiToastManager toastManager,
+    ILogger<SimilarSongsViewModel> logger)
+    : ISimilarSongsViewModelFactory
+{
+    public SimilarSongsViewModel Create(SongItem sourceSong)
+    {
+        return new SimilarSongsViewModel(recommendClient, toastManager, logger, sourceSong);
+    }
+}
+
 public interface IDiscoverTagViewModelFactory
 {
     DiscoverTagViewModel Create();

--- a/src/Apps/KugouAvaloniaPlayer/Views/DailyRecommendView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/DailyRecommendView.axaml
@@ -331,7 +331,25 @@
                         <TextBlock Classes="daily-table-heading" Text="歌曲" />
                         <TextBlock Grid.Column="1" Classes="daily-table-heading" Text="专辑" />
                         <TextBlock Grid.Column="2" Classes="daily-table-heading" Text="时长" />
-                        <TextBlock Grid.Column="3" Classes="daily-table-heading" Text="操作" HorizontalAlignment="Right" Margin="0,0,50,0" />
+                        <StackPanel Grid.Column="3"
+                                    Orientation="Horizontal"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Spacing="8">
+                            <TextBlock Classes="daily-table-heading"
+                                       Text="操作"
+                                       Margin="0,0,50,0" />
+                            <Button Classes="fm-inline-icon"
+                                    Width="30"
+                                    Height="30"
+                                    ToolTip.Tip="刷新每日推荐"
+                                    IsEnabled="{Binding !IsDailyRecommendationsLoading}"
+                                    Command="{Binding RefreshDailyRecommendationsCommand}">
+                                <PathIcon Data="{x:Static suki:Icons.Refresh}"
+                                          Width="15"
+                                          Height="15" />
+                            </Button>
+                        </StackPanel>
                     </Grid>
 
                     <Grid Grid.Row="1">
@@ -351,7 +369,9 @@
                                         PlayCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).PlaySongCommand}"
                                         AddToNextCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).AddSongToNextCommand}"
                                         ShowPlaylistDialogCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).ShowSongPlaylistDialogCommand}"
-                                        ViewSingerCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).ViewSongSingerCommand}" />
+                                        ViewSingerCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).ViewSongSingerCommand}"
+                                        ShowSimilarSongsCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).ShowSimilarSongsCommand}"
+                                        SearchSongCommand="{Binding #DailyRecommendRoot.((vm:DailyRecommendViewModel)DataContext).SearchSongCommand}" />
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>

--- a/src/Apps/KugouAvaloniaPlayer/Views/DiscoverTagView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/DiscoverTagView.axaml
@@ -101,8 +101,8 @@
                                Foreground="{DynamicResource SukiLiquid2}" />
                 </StackPanel>
 
-                <ScrollViewer IsVisible="{Binding !IsLoading}" Padding="0,0,0,-50">
-                    <ItemsRepeater ItemsSource="{Binding Playlists}">
+                <ScrollViewer IsVisible="{Binding !IsLoading}">
+                    <ItemsRepeater ItemsSource="{Binding Playlists}" Margin="0,0,0,50">
                         <ItemsRepeater.Layout>
                             <UniformGridLayout MinItemWidth="184"
                                                MinItemHeight="236"

--- a/src/Apps/KugouAvaloniaPlayer/Views/DiscoverView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/DiscoverView.axaml
@@ -80,9 +80,8 @@
     <Grid Margin="15">
         <Grid IsVisible="{Binding !IsShowingSongs}">
             <ScrollViewer HorizontalScrollBarVisibility="Disabled"
-                          VerticalScrollBarVisibility="Auto"
-                          Padding="0,0,0,-90">
-                <StackPanel Spacing="26">
+                          VerticalScrollBarVisibility="Auto">
+                <StackPanel Spacing="26" Margin="0,0,0,90">
                     <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,-4">
                         <TextBlock Text="探索发现"
                                    FontSize="30"

--- a/src/Apps/KugouAvaloniaPlayer/Views/LocalMusicLibraryView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/LocalMusicLibraryView.axaml
@@ -89,8 +89,8 @@
 
                 </Grid>
 
-                <ScrollViewer Grid.Row="1" Padding="0,0,0,-50">
-                    <ItemsRepeater ItemsSource="{Binding LocalLibraryPlaylists}">
+                <ScrollViewer Grid.Row="1">
+                    <ItemsRepeater ItemsSource="{Binding LocalLibraryPlaylists}" Margin="0,0,0,50">
                         <ItemsRepeater.Layout>
                             <UniformGridLayout MinItemWidth="184"
                                                MinItemHeight="236"

--- a/src/Apps/KugouAvaloniaPlayer/Views/NowPlayingThemes/StandardNowPlayingThemeView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/NowPlayingThemes/StandardNowPlayingThemeView.axaml
@@ -155,6 +155,24 @@
             </Border>
         </Button>
 
+        <Button Cursor="Hand"
+                Command="{Binding ShowSimilarSongsCommand}"
+                Classes="Basic"
+                ToolTip.Tip="相似歌曲推荐"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Margin="40,140,0,0">
+            <Border Classes="PortraitModeButton"
+                    CornerRadius="20"
+                    Padding="12,8">
+                <Svg Path="/Assets/music-party-svgrepo-com.svg"
+                     Css="path { fill: white; }"
+                     Width="22"
+                     Height="22"
+                     Opacity="0.9" />
+            </Border>
+        </Button>
+
         <Grid ColumnDefinitions="4*, 6*"
               Margin="40,120,40,68">
             <StackPanel Grid.Column="0"

--- a/src/Apps/KugouAvaloniaPlayer/Views/RankView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/RankView.axaml
@@ -48,8 +48,8 @@
                            VerticalAlignment="Center" />
             </StackPanel>
 
-            <ScrollViewer Grid.Row="1" Padding="0,0,0,-50">
-                <ItemsControl ItemsSource="{Binding RankSections}">
+            <ScrollViewer Grid.Row="1">
+                <ItemsControl ItemsSource="{Binding RankSections}" Margin="0,0,0,50">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="vm:RankSection">
                             <StackPanel Margin="0,0,0,22">

--- a/src/Apps/KugouAvaloniaPlayer/Views/SearchView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/SearchView.axaml
@@ -113,12 +113,14 @@
                                     PlayCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).PlaySongCommand}"
                                     AddToNextCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).AddSongToNextCommand}"
                                     ShowPlaylistDialogCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).ShowSongPlaylistDialogCommand}"
-                                    ViewSingerCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).ViewSongSingerCommand}" />
+                                    ViewSingerCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).ViewSongSingerCommand}"
+                                    ShowSimilarSongsCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).ShowSimilarSongsCommand}"
+                                    SearchSongCommand="{Binding #SearchRoot.((vm:SearchViewModel)DataContext).SearchSongCommand}" />
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>
 
-                    <ScrollViewer Padding="0,0,0,-50">
+                    <ScrollViewer>
                         <ScrollViewer.IsVisible>
                             <MultiBinding Converter="{x:Static BoolConverters.And}">
                                 <Binding Path="HasSearched" />
@@ -129,7 +131,7 @@
                                 <Binding Path="!IsShowingDetail" />
                             </MultiBinding>
                         </ScrollViewer.IsVisible>
-                        <ItemsRepeater ItemsSource="{Binding Playlists}">
+                        <ItemsRepeater ItemsSource="{Binding Playlists}" Margin="0,0,0,50">
                             <ItemsRepeater.Layout>
                                 <UniformGridLayout MinItemWidth="184"
                                                    MinItemHeight="236"
@@ -148,7 +150,7 @@
                         </ItemsRepeater>
                     </ScrollViewer>
 
-                    <ScrollViewer Padding="0,0,0,-50">
+                    <ScrollViewer>
                         <ScrollViewer.IsVisible>
                             <MultiBinding Converter="{x:Static BoolConverters.And}">
                                 <Binding Path="HasSearched" />
@@ -159,7 +161,7 @@
                                 <Binding Path="!IsShowingDetail" />
                             </MultiBinding>
                         </ScrollViewer.IsVisible>
-                        <ItemsRepeater ItemsSource="{Binding Albums}">
+                        <ItemsRepeater ItemsSource="{Binding Albums}" Margin="0,0,0,50">
                             <ItemsRepeater.Layout>
                                 <UniformGridLayout MinItemWidth="184"
                                                    MinItemHeight="236"
@@ -178,7 +180,7 @@
                         </ItemsRepeater>
                     </ScrollViewer>
 
-                    <ScrollViewer Padding="0,0,0,-50">
+                    <ScrollViewer>
                         <ScrollViewer.IsVisible>
                             <MultiBinding Converter="{x:Static BoolConverters.And}">
                                 <Binding Path="HasSearched" />
@@ -189,7 +191,7 @@
                                 <Binding Path="!IsShowingDetail" />
                             </MultiBinding>
                         </ScrollViewer.IsVisible>
-                        <ItemsRepeater ItemsSource="{Binding Singers}">
+                        <ItemsRepeater ItemsSource="{Binding Singers}" Margin="0,0,0,50">
                             <ItemsRepeater.Layout>
                                 <UniformGridLayout MinItemWidth="184"
                                                    MinItemHeight="236"

--- a/src/Apps/KugouAvaloniaPlayer/Views/SimilarSongsView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/SimilarSongsView.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:KugouAvaloniaPlayer.ViewModels"
+             xmlns:localControls="using:KugouAvaloniaPlayer.Controls"
+             x:Class="KugouAvaloniaPlayer.Views.SimilarSongsView"
+             x:Name="SimilarSongsRoot"
+             x:DataType="vm:SimilarSongsViewModel">
+
+    <Grid Margin="15">
+        <localControls:SongCollectionDetailView
+            PlaybackCommands="{Binding $parent[localControls:KugouWindow].((vm:MainWindowViewModel)DataContext).Player}"
+            SongInteractions="{Binding $parent[localControls:KugouWindow].((vm:MainWindowViewModel)DataContext).SongInteractions}"
+            Cover="{Binding SourceCover}"
+            Title="{Binding Title}"
+            Songs="{Binding Songs}"
+            BackCommand="{Binding $parent[localControls:KugouWindow].((vm:MainWindowViewModel)DataContext).NavigateBackCommand}"
+            IsLoading="{Binding IsLoading}"
+            LoadingText="正在加载相似歌曲..."
+            ListPadding="0,0,0,90"
+            TitleFontSize="24" />
+    </Grid>
+</UserControl>

--- a/src/Apps/KugouAvaloniaPlayer/Views/SimilarSongsView.axaml.cs
+++ b/src/Apps/KugouAvaloniaPlayer/Views/SimilarSongsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace KugouAvaloniaPlayer.Views;
+
+public partial class SimilarSongsView : UserControl
+{
+    public SimilarSongsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Apps/KugouAvaloniaPlayer/Views/SingerView.axaml
+++ b/src/Apps/KugouAvaloniaPlayer/Views/SingerView.axaml
@@ -51,11 +51,10 @@
                             Padding="22,16,22,0"
                             CornerRadius="18">
                 <Grid>
-                    <ScrollViewer Padding="0,0,0,-50"
-                                  VerticalScrollBarVisibility="Auto"
+                    <ScrollViewer VerticalScrollBarVisibility="Auto"
                                   HorizontalScrollBarVisibility="Disabled"
                                   behaviors:InteractionBehaviors.ScrollNearBottomCommand="{Binding LoadMoreAlbumsCommand}">
-                        <ItemsRepeater ItemsSource="{Binding Albums}">
+                        <ItemsRepeater ItemsSource="{Binding Albums}" Margin="0,0,0,50">
                             <ItemsRepeater.Layout>
                                 <UniformGridLayout MinItemWidth="184"
                                                    MinItemHeight="236"

--- a/src/Libraries/KuGou.Net/Abstractions/Models/AiRecommendResponse.cs
+++ b/src/Libraries/KuGou.Net/Abstractions/Models/AiRecommendResponse.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+using KuGou.Net.Abstractions.Models;
+
+namespace KuGou.Net.Abstractions.Models;
+
+/// <summary>
+///     AI 相似歌曲推荐返回的单曲信息。
+///     字段命名参照 <see cref="DailyRecommendSong" />，JSON key 在实跑校准后可能调整。
+/// </summary>
+public record AiRecommendSong : KgBaseModel
+{
+    /// <summary>歌曲名称</summary>
+    [property: JsonPropertyName("songname")]
+    public string Name { get; set; } = "";
+
+    /// <summary>歌手名称</summary>
+    [property: JsonPropertyName("author_name")]
+    public string SingerName { get; set; } = "";
+
+    /// <summary>文件 Hash (标准音质/128k)</summary>
+    [property: JsonPropertyName("hash")]
+    public string Hash { get; set; } = "";
+
+    /// <summary>时长 (秒)</summary>
+    [property: JsonPropertyName("time_length")]
+    public int Duration { get; set; }
+
+    /// <summary>专辑 ID</summary>
+    [property: JsonPropertyName("album_id")]
+    public string AlbumId { get; set; } = "";
+
+    /// <summary>专辑名称</summary>
+    [property: JsonPropertyName("album_name")]
+    public string AlbumName { get; set; } = "";
+
+    /// <summary>歌曲 ID (AudioID)</summary>
+    [property: JsonPropertyName("songid")]
+    public long AudioId { get; set; }
+
+    /// <summary>混合 ID / album_audio_id，用于再次发起相似推荐</summary>
+    [property: JsonPropertyName("mixsongid")]
+    public long AlbumAudioId { get; set; }
+
+    /// <summary>封面 (含 {size} 占位符)</summary>
+    [property: JsonPropertyName("sizable_cover")]
+    public string? SizableCover
+    {
+        get;
+        set => field = value?.Replace("{size}", "400");
+    }
+}

--- a/src/Libraries/KuGou.Net/Abstractions/Models/RankSongResponse.cs
+++ b/src/Libraries/KuGou.Net/Abstractions/Models/RankSongResponse.cs
@@ -43,6 +43,12 @@ public record RankSongItem : KgBaseModel
     public List<RankSongAuthor> Authors { get; set; } = new();
 
     /// <summary>
+    ///     混合 ID (album_audio_id)，用于相似推荐。榜单接口将其放在顶层。
+    /// </summary>
+    [property: JsonPropertyName("album_audio_id")]
+    public long AlbumAudioId { get; set; }
+
+    /// <summary>
     ///     歌曲名称。
     /// </summary>
     [property: JsonPropertyName("songname")]

--- a/src/Libraries/KuGou.Net/Abstractions/Models/SongModel.cs
+++ b/src/Libraries/KuGou.Net/Abstractions/Models/SongModel.cs
@@ -66,6 +66,12 @@ public record SongInfo : KgBaseModel
     public int Duration { get; set; }
 
     /// <summary>
+    ///     混合 ID (album_audio_id)，用于相似推荐等场景。
+    /// </summary>
+    [property: JsonPropertyName("MixSongID")]
+    public long AlbumAudioId { get; set; }
+
+    /// <summary>
     ///     封面图地址。
     /// </summary>
     [property: JsonPropertyName("Image")]

--- a/src/Libraries/KuGou.Net/util/AppJsonContext.cs
+++ b/src/Libraries/KuGou.Net/util/AppJsonContext.cs
@@ -134,6 +134,8 @@ namespace KuGou.Net.util;
 [JsonSerializable(typeof(List<PrivilegeLiteData>))]
 [JsonSerializable(typeof(RankListSongPreview))]
 [JsonSerializable(typeof(List<RankListSongPreview>))]
+[JsonSerializable(typeof(AiRecommendSong))]
+[JsonSerializable(typeof(List<AiRecommendSong>))]
 internal partial class AppJsonContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
## 概述

  本次包含多项 UI/交互改进与一个新功能,基于最新 master,跨平台兼容(纯托管代码,无平台专属 API)。

  ## 改动

  ### Bug 修复
  -
  **修复多个页面滚不到底**:`DiscoverView`/`DiscoverTagView`/`LocalMusicLibraryView`/`RankView`/`SearchView`/`SingerView`
  的 ScrollViewer 负 padding 改为内容底部 margin,滚动范围计算正确,底部内容不再被截断。

  ### 新功能
  - **每日推荐刷新按钮**:每日推荐页新增刷新按钮,无需重启即可更新当天推荐。
  - **相似歌曲推荐**:基于酷狗 `/recommend` AI 接口,给定一首歌展示相似推荐列表。
    - 入口:歌曲右键「相似歌曲推荐」+ 播放页顶部按钮
    - 复用 `SongCollectionDetailView`,仿 `SingerViewModel` 的 transient 页模式
    - 补全各页面 `SongItem.AlbumAudioId` 映射(搜索/歌手/榜单/歌单详情/发现/我喜欢/私人 FM),修复榜单接口 `album_audio_id`
  在顶层而非 `audio_info` 内的问题
  - **歌曲右键「搜索相关歌单」**:用歌名跳转搜索页并切到歌单分类,快速查找收录该歌的歌单(通过 `SearchRequestedEvent`
  解耦,避免循环依赖)
  - **私人 FM 第三个推荐池**:新增「特殊推荐池」(`song_pool_id=2`),toggle 三态循环

  ### 交互优化
  - **Toast 统一带 ✕ 关闭**:新增 `SukiToastExtensions.ShowDismissibleToast`,内容区右上角 ✕
  按钮可立即关闭,无需等倒计时。各 ViewModel/Service 纯文本 toast 统一替换(带操作按钮/进度条的保持不变)。
  - **弹窗统一加 ✕**:`AddToPlaylistDialog`/`SongBatchActionDialog`/`MultiPlaylistSelectionDialog`/`TrackPlaylistSearchDi
  alog`/`LyricMatchDialog` 标题区右上角加 ✕,移除底部「取消」/「关闭」按钮。

  ## 验证
  - Debug 构建 0 警告 0 错误
  - 基于 origin/master(含最新提交)无冲突 cherry-pick
  - 各功能已实跑验证:相似推荐全页面可用、Toast ✕ 可关闭、弹窗 ✕ 可关闭、滚动到底正常

  ## 兼容性
  改动均为纯托管 Avalonia + KuGou.Net 代码,无 Windows/macOS/Linux 专属 API,不影响现有跨平台构建与发布流程。